### PR TITLE
Change return type of countRange

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,5 +30,5 @@ node_modules
 # Vim swp
 *.swp
 
-# Ignore docs for now
-docs
+# Ignore docs output folder
+out

--- a/README.md
+++ b/README.md
@@ -12,15 +12,22 @@ In a sense, the libary tries to provide sugar-coated method calls for storing
 and fetching Redis data to report counts and trends. The first design goal is to
 make counting simpler.
 
-Usage
+Install
+-------
+
+```console
+$ npm install --save redis-metrics
+```
+
+Use
 ----- 
 
-```node
-// Create an instance of the me
+```javascript
+// Create an instance
 var RedisMetrics = require('redis-metrics');
 var metrics = new RedisMetrics();
 
-// Get a counter for a "pageview" event and increment it three times.
+// Create a counter for a "pageview" event and increment it three times.
 var myCounter = metrics.counter('pageview');
 myCounter.incr();
 myCounter.incr();

--- a/jsdoc.json
+++ b/jsdoc.json
@@ -1,0 +1,11 @@
+{
+  "source": {
+    "include": [ "lib/" ]
+  },
+  "opts": {
+    "destination": "out/",
+    "tutorials": "docs/",
+    "recurse": true,
+    "readme": "README.md"
+  }
+}

--- a/lib/counter.js
+++ b/lib/counter.js
@@ -19,6 +19,19 @@ var parseTimeGranularity = function(timeGranularity) {
 };
 
 /**
+ * Creates a function that parses a list of Redis results and matches them up
+ * with the given keyRange
+ * @param {array} keyRange - The list of keys to match with the results.
+ * @returns {function}
+ * @private
+ */
+var createRangeParser = function(keyRange) {
+  return function(results) {
+    return _.zipObject(keyRange, utils.parseIntArray(results));
+  };
+};
+
+/**
  * A timestamped event counter.
  *
  * This constructor is usually not called directly but through the
@@ -50,7 +63,7 @@ function TimestampedCounter(metrics, key, options) {
 
 /**
  * Return a list of Redis keys that are associated with this counter at the
- * current point in time and will be written.
+ * current point in time and will be written to Redis.
  * @returns {Array}
  */
 TimestampedCounter.prototype.getKeys = function() {
@@ -70,7 +83,7 @@ TimestampedCounter.prototype.getKeys = function() {
 };
 
 /**
- * Increments this counter with the given value.
+ * Increments this counter with 1.
  *
  * @param {function} [callback] - Optional callback.
  * @returns {Promise} A promise that resolves to the results from Redis. Can
@@ -101,6 +114,15 @@ TimestampedCounter.prototype.incr = function(callback) {
  * value at the given granularity level. Effectively, this provides a single
  * answer to questions such as "what is the count for the current day".
  *
+ * @example
+ * myCounter.count(function(err, result) {
+ *   console.log(result); // Outputs the global count
+ * });
+ * @example
+ * myCounter.count('year', function(err, result) {
+ *   console.log(result); // Outputs the count for the current year
+ * });
+ *
  * @param {module:constants~timeGranularities} [timeGranularity] - The
  * granularity level to report the count for.
  * @param {function} [callback] - Optional callback.
@@ -122,32 +144,52 @@ TimestampedCounter.prototype.count = function(timeGranularity, callback) {
 };
 
 /**
- * Returns a list of counts in the given time range at a specific granularity
- * level.
+ * Returns a object mapping timestamps to counts in the given time range at a
+ * specific time granularity level.
  *
  * Notice: This function does not make sense for the "none" time granularity.
  *
- * @param {module:constants~timeGranularities} [timeGranularity] - The
- * granularity level to report the count for.
- * @param {Date} startDate - Start date for the range (inclusive)
- * @param {Date} [endDate=new Date()] - End date for the range (inclusive).
+ * @param {module:constants~timeGranularities} timeGranularity - The
+ *   granularity level to report the count for.
+ * @param {Date|Object|string|number} startDate - Start date for the range
+ *   (inclusive). Accepts the same argument as the constructor of a
+ *   {@link http://momentjs.com/|moment} date.
+ * @param {Date|Object|string|number} [endDate=new Date()] - End date for the
+ *   range (inclusive). Accepts the same arguments as the constructor of a
+ *   {@link http://momentjs.com/|moment} date.
  * @param {function} [callback] - Optional callback.
  * @returns {Promise} A promise that resolves to the result from Redis. Can
- * be used instead of the callback function.
+ *   be used instead of the callback function.
  */
 TimestampedCounter.prototype.countRange =
     function(timeGranularity, startDate, endDate, callback) {
   timeGranularity = parseTimeGranularity(timeGranularity);
-  endDate = endDate || moment.utc();
-  var deferred = Q.defer();
-  var cb = utils.createRedisCallback(deferred, callback, utils.parseIntArray);
+  if (typeof endDate === 'function') {
+    callback = endDate;
+    endDate = moment.utc();
+  } else {
+    endDate = endDate || moment.utc();
+  }
 
   var momentRange = utils.momentRange(startDate, endDate, timeGranularity);
   var _this = this;
-  var keyRange = momentRange.map(function(m) {
-    return _this.key + ':' +
-      m.format(momentFormat).slice(0, timeGranularity*2+2);
+  var keyRange = [];
+  var momentKeyRange = [];
+
+  // Create the range of keys to fetch from Redis as well as the keys to use in
+  // the returned data object.
+  momentRange.forEach(function(m) {
+    // Redis key range
+    keyRange.push(
+      _this.key + ':' + m.format(momentFormat).slice(0, timeGranularity*2+2));
+
+    // Timestamp range. Use ISO format for easy parsing back to a timestamp.
+    momentKeyRange.push(m.format());
   });
+
+  var deferred = Q.defer();
+  var rangeParser = createRangeParser(momentKeyRange);
+  var cb = utils.createRedisCallback(deferred, callback, rangeParser);
 
   this.metrics.client.mget(keyRange, cb);
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/metrics.js",
   "scripts": {
     "test": "node_modules/.bin/istanbul cover node_modules/.bin/_mocha",
-    "docs": "node_modules/.bin/jsdoc ./lib/ -r -P ./package.json -d ./docs/"
+    "docs": "node_modules/.bin/jsdoc -c jsdoc.json"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Change the return type for countRange so it returns an object
timestamp-count pairs instead of an array of just the counts.

Other changes (sorry):
- Update README.
- Add configuration for jsdoc.
- Change jsdoc output directory.
