### PR TITLE
Add support for extra event object

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ $ npm install --save redis-metrics
 Use
 ----- 
 
+Basic counter:
+
 ```javascript
 // Create an instance
 var RedisMetrics = require('redis-metrics');
@@ -49,6 +51,57 @@ myCounter.count(function(cnt) {
 myCounter.count().then(function(cnt) {
   console.log(cnt); // Outputs 3 to the console.
 });
+```
+
+Time-aware counter.
+
+```javascript
+// Create an instance
+var RedisMetrics = require('redis-metrics');
+var metrics = new RedisMetrics();
+
+// Use the timeGranularity option to specify how specific the counter should be
+// when incrementing.
+var myCounter = metrics.counter('pageview', { timeGranularity: 'hour' });
+
+// Fetch the count for myCounter for the current year.
+myCounter.count('year')
+  .then(function(cnt) {
+    console.log(cnt); // Outputs 3 to the console.
+  });
+
+// Fetch the count for each of the last two hours.
+// We are using moment here for convenience.
+var moment = require('moment');
+var now = moment();
+var lastHour = moment(now).add(-1, 'hours');
+myCounter.countRange('hour', lastHour, now)
+  .then(function(obj) {
+    // "obj" is an object with timestamps as keys and counts as values.
+    // For example something like this:
+    // {
+    //   '2015-04-15T11:00:00+00:00': 2,
+    //   '2015-04-15T12:00:00+00:00': 3
+    // }
+  });
+
+// Fetch the count for each day in the last 30 days
+var thirtyDaysAgo = moment(now).add(-30, 'days');
+myCounter.countRange('day', thirtyDaysAgo, now)
+  .then(function(obj) {
+    // "obj" contains counter information for each of the last thirty days.
+    // For example something like this:
+    // {
+    //   '2015-03-16T00:00:00+00:00': 2,
+    //   '2015-03-17T00:00:00+00:00': 3,
+    //   ...
+    //   '2015-04-15T00:00:00+00:00': 1
+    // }
+  });
+
+// Fetch the count for the last 60 seconds...
+// ... Sorry, you can't do that because the counter is only set up to track by
+// the hour.
 ```
 
 Test

--- a/benchmark.js
+++ b/benchmark.js
@@ -10,6 +10,11 @@ var hourCounter = metrics.counter('hour', {
   timeGranularity: 'hour'
 });
 
+var eventObjectCounter = metrics.counter('event');
+var eventObjectHourCounter = metrics.counter('eventHour', {
+  timeGranularity: 'hour'
+});
+
 function Test(options) {
   this.name = options.name;
   this.iterations = options.iterations;
@@ -37,7 +42,7 @@ Test.prototype.run = function(onComplete) {
   };
 
   for (var i = 0; i < this.iterations; i++) {
-    this.testFunction(testCallback);
+    this.testFunction(testCallback, i);
   }
 };
 
@@ -80,25 +85,46 @@ tests.push(new Test({
 
 // Counter per user
 
+var users = []
+for (var i = 0; i < 10000; i++) {
+  users.push(crypto.pseudoRandomBytes(16).toString('hex'));
+}
+
 tests.push(new Test({
-  name: 'incr random simple 10000',
+  name: 'incr user counter simple 10000',
   iterations: 10000,
-  testFunction: function(callback) {
+  testFunction: function(callback, iteration) {
     metrics
-      .counter(crypto.pseudoRandomBytes(16).toString('hex'))
+      .counter(users[iteration])
       .incr(callback);
   }
 }));
 
 tests.push(new Test({
-  name: 'incr random hour 10000',
+  name: 'incr user counter hour 10000',
   iterations: 10000,
-  testFunction: function(callback) {
+  testFunction: function(callback, iteration) {
     metrics
-      .counter(crypto.pseudoRandomBytes(16).toString('hex'), {
+      .counter(users[iteration], {
         timeGranularity: 'hour'
       })
       .incr(callback);
+  }
+}));
+
+tests.push(new Test({
+  name: 'incr counter sorted user set 10000',
+  iterations: 10000,
+  testFunction: function(callback, iteration) {
+    eventObjectCounter.incr(users[iteration], callback);
+  }
+}));
+
+tests.push(new Test({
+  name: 'incr hour counter sorted user set 10000',
+  iterations: 10000,
+  testFunction: function(callback, iteration) {
+    eventObjectHourCounter.incr(users[iteration], callback);
   }
 }));
 

--- a/benchmarks/general.js
+++ b/benchmarks/general.js
@@ -6,7 +6,7 @@
 
 var util = require('util'),
     crypto = require('crypto'),
-    RedisMetrics = require('./lib/metrics');
+    RedisMetrics = require('../lib/metrics');
 
 var metrics = new RedisMetrics();
 var simpleCounter = metrics.counter('simple');

--- a/benchmarks/general.js
+++ b/benchmarks/general.js
@@ -1,5 +1,9 @@
 'use strict';
 
+/**
+ * General performance benchmarks
+ */
+
 var util = require('util'),
     crypto = require('crypto'),
     RedisMetrics = require('./lib/metrics');

--- a/benchmarks/general.js
+++ b/benchmarks/general.js
@@ -89,7 +89,7 @@ tests.push(new Test({
 
 // Counter per user
 
-var users = []
+var users = [];
 for (var i = 0; i < 10000; i++) {
   users.push(crypto.pseudoRandomBytes(16).toString('hex'));
 }

--- a/benchmarks/memory.js
+++ b/benchmarks/memory.js
@@ -8,7 +8,7 @@ var util = require('util'),
     crypto = require('crypto'),
     sinon = require('sinon'),
     async = require('async'),
-    RedisMetrics = require('./lib/metrics');
+    RedisMetrics = require('../lib/metrics');
 
 var metrics = new RedisMetrics();
 var counter = metrics.counter('impression', {

--- a/benchmarks/memory.js
+++ b/benchmarks/memory.js
@@ -4,8 +4,7 @@
  * Benchmark to push the memory.
  */
 
-var util = require('util'),
-    crypto = require('crypto'),
+var crypto = require('crypto'),
     sinon = require('sinon'),
     async = require('async'),
     RedisMetrics = require('../lib/metrics');
@@ -28,8 +27,6 @@ var hours = [];
 for (var hour = 0; hour < 24; hour++) {
   hours.push(hour);
 }
-
-var currentHour = 0;
 
 var clock = sinon.useFakeTimers();
 async.eachSeries(hours, function(hour, hourDone) {

--- a/benchmarks/memory.js
+++ b/benchmarks/memory.js
@@ -1,0 +1,47 @@
+'use strict';
+
+/**
+ * Benchmark to push the memory.
+ */
+
+var util = require('util'),
+    crypto = require('crypto'),
+    sinon = require('sinon'),
+    async = require('async'),
+    RedisMetrics = require('./lib/metrics');
+
+var metrics = new RedisMetrics();
+var counter = metrics.counter('impression', {
+  timeGranularity: 'hour'
+});
+
+metrics.client.on('error', function(err) {
+  console.log('Err', err);
+});
+
+var users = [];
+for (var i = 0; i < 10000; i++) {
+  users.push(crypto.pseudoRandomBytes(16).toString('hex'));
+}
+
+var hours = [];
+for (var hour = 0; hour < 24; hour++) {
+  hours.push(hour);
+}
+
+var currentHour = 0;
+
+var clock = sinon.useFakeTimers();
+async.eachSeries(hours, function(hour, hourDone) {
+  console.log('Time is now:', new Date());
+  async.eachSeries(users, function(user, userDone) {
+    counter.incr(user, userDone);
+  }, function(err) {
+    clock.tick(1000*60*60);
+    hourDone(err);
+  });
+}, function(err) {
+  console.log('All done', err);
+  clock.restore();
+  process.exit(0);
+});

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -21,6 +21,7 @@
  */
 var timeGranularities = {
   // Long string form
+  total: 0,
   none: 0,
   year: 1,
   month: 2,
@@ -31,6 +32,8 @@ var timeGranularities = {
 
   // Short string form
 
+  /** Short form of "total" */
+  T: 0,
   /** Short form of "none" */
   N: 0,
   /** Short form of "year" */

--- a/lib/counter.js
+++ b/lib/counter.js
@@ -49,6 +49,8 @@ var createRangeParser = function(keyRange) {
  *
  * @param {RedisMetrics} metrics - An instance of a RedisMetrics client.
  * @param {string} key - The base key to use for this counter.
+ * @param {Object} options - The options to use for this counter. The available
+ * options are specified in {@link RedisMetrics#counter}.
  * @class
  */
 function TimestampedCounter(metrics, key, options) {
@@ -85,21 +87,42 @@ TimestampedCounter.prototype.getKeys = function() {
 /**
  * Increments this counter with 1.
  *
+ * For some use cases, it makes sense to pass in an event object to get more
+ * precise statistics for a specific event. For example, when counting page
+ * views on a page, it makes sense to increment a counter per specific page.
+ * For this use case, the eventObj parameter is a good fit.
+ *
+ * @param {Object|string} [eventObj] - Extra event information used to
+ * determine what counter to increment.
  * @param {function} [callback] - Optional callback.
  * @returns {Promise} A promise that resolves to the results from Redis. Can
  * be used instead of the callback function.
  */
-TimestampedCounter.prototype.incr = function(callback) {
+TimestampedCounter.prototype.incr = function(eventObj, callback) {
+  if (typeof eventObj === 'function') {
+    callback = eventObj;
+    eventObj = null;
+  }
+
   var deferred = Q.defer();
   var cb = utils.createRedisCallback(deferred, callback);
 
-  var keysToIncrement = this.getKeys();
-  if (keysToIncrement.length === 1) {
-    this.metrics.client.incr(keysToIncrement[0], cb);
+  var keys = this.getKeys();
+  // Optimize for the case where there is only a single key to increment.
+  if (keys.length === 1) {
+    if (eventObj) {
+      this.metrics.client.zincrby('cz:' + keys[0], 1, eventObj, cb);
+    } else {
+      this.metrics.client.incr('c:' + keys[0], cb);
+    }
   } else {
     var multi = this.metrics.client.multi();
-    keysToIncrement.forEach(function(key) {
-      multi.incr(key);
+    keys.forEach(function(key) {
+      if (eventObj) {
+        multi.zincrby('cz:' + key, 1, eventObj);
+      } else {
+        multi.incr('c:' + key);
+      }
     });
     multi.exec(cb);
   }
@@ -113,6 +136,9 @@ TimestampedCounter.prototype.incr = function(callback) {
  * If a specific time granularity is given, the value returned is the current
  * value at the given granularity level. Effectively, this provides a single
  * answer to questions such as "what is the count for the current day".
+ *
+ * Notice that counts cannot be returned for a given time granularity if it was
+ * not incremented at this granularity in the first place.
  *
  * @example
  * myCounter.count(function(err, result) {
@@ -139,7 +165,7 @@ TimestampedCounter.prototype.count = function(timeGranularity, callback) {
 
   var deferred = Q.defer();
   var cb = utils.createRedisCallback(deferred, callback, utils.parseInt);
-  this.metrics.client.get(this.getKeys()[timeGranularity], cb);
+  this.metrics.client.get('c:' + this.getKeys()[timeGranularity], cb);
   return deferred.promise;
 };
 
@@ -181,7 +207,9 @@ TimestampedCounter.prototype.countRange =
   momentRange.forEach(function(m) {
     // Redis key range
     keyRange.push(
-      _this.key + ':' + m.format(momentFormat).slice(0, timeGranularity*2+2));
+      'c:' +
+      _this.key + ':' +
+      m.format(momentFormat).slice(0, timeGranularity*2+2));
 
     // Timestamp range. Use ISO format for easy parsing back to a timestamp.
     momentKeyRange.push(m.format());

--- a/lib/counter.js
+++ b/lib/counter.js
@@ -98,6 +98,7 @@ TimestampedCounter.prototype.getKeys = function() {
  * @param {function} [callback] - Optional callback.
  * @returns {Promise} A promise that resolves to the results from Redis. Can
  *   be used instead of the callback function.
+ * @since 0.1.0
  */
 TimestampedCounter.prototype.incr = function(eventObj, callback) {
   return this.incrby(1, eventObj, callback);
@@ -113,6 +114,7 @@ TimestampedCounter.prototype.incr = function(eventObj, callback) {
  * @returns {Promise} A promise that resolves to the results from Redis. Can
  *   be used instead of the callback function.
  * @see {@link TimestampedCounter#incr}
+ * @since 0.2.0
  */
 TimestampedCounter.prototype.incrby = function(amount, eventObj, callback) {
   // The event object is optional so it might be a callback.
@@ -180,6 +182,7 @@ TimestampedCounter.prototype._incrby = function(amount, eventObj, cb) {
  * @param {function} [callback] - Optional callback.
  * @returns {Promise} A promise that resolves to the result from Redis. Can
  *   be used instead of the callback function.
+ * @since 0.1.0
  */
 TimestampedCounter.prototype.count = function(
     timeGranularity, eventObj, callback) {
@@ -231,6 +234,7 @@ TimestampedCounter.prototype._count = function(timeGranularity, eventObj, cb) {
  * @param {function} [callback] - Optional callback.
  * @returns {Promise} A promise that resolves to the result from Redis. Can
  *   be used instead of the callback function.
+ * @since 0.1.0
  */
 TimestampedCounter.prototype.countRange = function(
     timeGranularity, startDate, endDate, eventObj, callback) {

--- a/lib/counter.js
+++ b/lib/counter.js
@@ -55,7 +55,7 @@ var createRangeParser = function(keyRange) {
  */
 function TimestampedCounter(metrics, key, options) {
   this.metrics = metrics;
-  this.key = key;
+  this.key = 'c:' + key; // Pre-prend c to indicate it's a counter.
   this.options = options || {};
   _.defaults(this.options, defaults);
 
@@ -69,7 +69,8 @@ function TimestampedCounter(metrics, key, options) {
  * @returns {Array}
  */
 TimestampedCounter.prototype.getKeys = function() {
-  var keys = [this.key]; // Always add the key itself.
+  // Always add the key itself.
+  var keys = [this.key];
 
   // If no time granularity is chosen, the timestamped keys will not be used so
   // just return the default key.
@@ -93,41 +94,59 @@ TimestampedCounter.prototype.getKeys = function() {
  * For this use case, the eventObj parameter is a good fit.
  *
  * @param {Object|string} [eventObj] - Extra event information used to
- * determine what counter to increment.
+ *   determine what counter to increment.
  * @param {function} [callback] - Optional callback.
  * @returns {Promise} A promise that resolves to the results from Redis. Can
- * be used instead of the callback function.
+ *   be used instead of the callback function.
  */
 TimestampedCounter.prototype.incr = function(eventObj, callback) {
-  if (typeof eventObj === 'function') {
+  return this.incrby(1, eventObj, callback);
+};
+
+/**
+ * Increments this counter with the given amount.
+ *
+ * @param {number} amount - The amount to increment with.
+ * @param {Object|string} [eventObj] - Extra event information used to
+ *   determine what counter to increment. See {@link TimestampedCounter#incr}.
+ * @param {function} [callback] - Optional callback.
+ * @returns {Promise} A promise that resolves to the results from Redis. Can
+ *   be used instead of the callback function.
+ * @see {@link TimestampedCounter#incr}
+ */
+TimestampedCounter.prototype.incrby = function(amount, eventObj, callback) {
+  // The event object is optional so it might be a callback.
+  if (_.isFunction(eventObj)) {
     callback = eventObj;
     eventObj = null;
   }
-
+  if (eventObj) eventObj = String(eventObj);
   var deferred = Q.defer();
   var cb = utils.createRedisCallback(deferred, callback);
+  this._incrby(amount, eventObj, cb);
+  return deferred.promise;
+};
 
+TimestampedCounter.prototype._incrby = function(amount, eventObj, cb) {
   var keys = this.getKeys();
   // Optimize for the case where there is only a single key to increment.
   if (keys.length === 1) {
     if (eventObj) {
-      this.metrics.client.zincrby('cz:' + keys[0], 1, eventObj, cb);
+      this.metrics.client.zincrby(keys[0] + ':z', amount, eventObj, cb);
     } else {
-      this.metrics.client.incr('c:' + keys[0], cb);
+      this.metrics.client.incrby(keys[0], amount, cb);
     }
   } else {
     var multi = this.metrics.client.multi();
     keys.forEach(function(key) {
       if (eventObj) {
-        multi.zincrby('cz:' + key, 1, eventObj);
+        multi.zincrby(key + ':z', amount, eventObj);
       } else {
-        multi.incr('c:' + key);
+        multi.incrby(key, amount);
       }
     });
     multi.exec(cb);
   }
-
-  return deferred.promise;
 };
 
 /**
@@ -138,7 +157,7 @@ TimestampedCounter.prototype.incr = function(eventObj, callback) {
  * answer to questions such as "what is the count for the current day".
  *
  * Notice that counts cannot be returned for a given time granularity if it was
- * not incremented at this granularity in the first place.
+ * not incremented at this granularity level in the first place.
  *
  * @example
  * myCounter.count(function(err, result) {
@@ -148,25 +167,49 @@ TimestampedCounter.prototype.incr = function(eventObj, callback) {
  * myCounter.count('year', function(err, result) {
  *   console.log(result); // Outputs the count for the current year
  * });
+ * @example
+ * myCounter.count('year', '/foo.html', function(err, result) {
+ *   // Outputs the count for the current year for the event object '/foo.html'
+ *   console.log(result);
+ * });
  *
- * @param {module:constants~timeGranularities} [timeGranularity] - The
- * granularity level to report the count for.
+ * @param {module:constants~timeGranularities} [timeGranularity='total'] - The
+ *   granularity level to report the count for.
+ * @param {string|object} [eventObj] - The event object. See
+ *   {@link TimestampedCounter#incr} for more info on event objects.
  * @param {function} [callback] - Optional callback.
  * @returns {Promise} A promise that resolves to the result from Redis. Can
- * be used instead of the callback function.
+ *   be used instead of the callback function.
  */
-TimestampedCounter.prototype.count = function(timeGranularity, callback) {
-  if (typeof timeGranularity === 'function') {
-    callback = timeGranularity;
-    timeGranularity = timeGranularities.none;
-  } else {
-    timeGranularity = parseTimeGranularity(timeGranularity);
-  }
+TimestampedCounter.prototype.count = function(
+    timeGranularity, eventObj, callback) {
+  var args = Array.prototype.slice.call(arguments);
+
+  // Last argument is callback;
+  callback = typeof args[args.length - 1] === 'function' ? args.pop() : null;
+
+  // Event object requires that the time granularity is specified, otherwise we
+  // can't reliably distinguish between them because both the eventObj and time
+  // granularity can be strings. I miss Python.
+  eventObj = args.length > 1 ? args.pop() : null;
+
+  // Still any arguments left? That's a time granularity.
+  timeGranularity = args.length > 0 ? args.pop() : 'none';
+  timeGranularity = parseTimeGranularity(timeGranularity);
 
   var deferred = Q.defer();
   var cb = utils.createRedisCallback(deferred, callback, utils.parseInt);
-  this.metrics.client.get('c:' + this.getKeys()[timeGranularity], cb);
+  this._count(timeGranularity, eventObj, cb);
   return deferred.promise;
+};
+
+TimestampedCounter.prototype._count = function(timeGranularity, eventObj, cb) {
+  var theKey = this.getKeys()[timeGranularity];
+  if (eventObj) {
+    this.metrics.client.zscore(theKey + ':z', eventObj, cb);
+  } else {
+    this.metrics.client.get(theKey, cb);
+  }
 };
 
 /**
@@ -183,19 +226,26 @@ TimestampedCounter.prototype.count = function(timeGranularity, callback) {
  * @param {Date|Object|string|number} [endDate=new Date()] - End date for the
  *   range (inclusive). Accepts the same arguments as the constructor of a
  *   {@link http://momentjs.com/|moment} date.
+ * @param {string|object} [eventObj] - The event object. See
+ *   {@link TimestampedCounter#incr} for more info on event objects.
  * @param {function} [callback] - Optional callback.
  * @returns {Promise} A promise that resolves to the result from Redis. Can
  *   be used instead of the callback function.
  */
-TimestampedCounter.prototype.countRange =
-    function(timeGranularity, startDate, endDate, callback) {
+TimestampedCounter.prototype.countRange = function(
+    timeGranularity, startDate, endDate, eventObj, callback) {
   timeGranularity = parseTimeGranularity(timeGranularity);
-  if (typeof endDate === 'function') {
+  if (_.isFunction(eventObj)) {
+    callback = eventObj;
+    eventObj = null;
+  }
+  else if (_.isFunction(endDate)) {
     callback = endDate;
     endDate = moment.utc();
   } else {
     endDate = endDate || moment.utc();
   }
+  if (eventObj) eventObj = String(eventObj);
 
   var momentRange = utils.momentRange(startDate, endDate, timeGranularity);
   var _this = this;
@@ -206,10 +256,8 @@ TimestampedCounter.prototype.countRange =
   // the returned data object.
   momentRange.forEach(function(m) {
     // Redis key range
-    keyRange.push(
-      'c:' +
-      _this.key + ':' +
-      m.format(momentFormat).slice(0, timeGranularity*2+2));
+    var mKeyFormat = m.format(momentFormat).slice(0, timeGranularity*2+2);
+    keyRange.push(_this.key + ':' + mKeyFormat);
 
     // Timestamp range. Use ISO format for easy parsing back to a timestamp.
     momentKeyRange.push(m.format());
@@ -219,9 +267,21 @@ TimestampedCounter.prototype.countRange =
   var rangeParser = createRangeParser(momentKeyRange);
   var cb = utils.createRedisCallback(deferred, callback, rangeParser);
 
-  this.metrics.client.mget(keyRange, cb);
+  this._countRange(keyRange, eventObj, cb);
 
   return deferred.promise;
+};
+
+TimestampedCounter.prototype._countRange = function(keys, eventObj, cb) {
+  if (eventObj) {
+    var multi = this.metrics.client.multi();
+    keys.forEach(function(key) {
+      multi.zscore(key + ':z', eventObj);
+    });
+    multi.exec(cb);
+  } else {
+    this.metrics.client.mget(keys, cb);
+  }
 };
 
 module.exports = TimestampedCounter;

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -46,6 +46,7 @@ function RedisMetrics(config) {
  * timestamps which means that it can be used to measure event metrics based on
  * time intervals. The default is to not use time granularities.
  * @returns {TimestampedCounter}
+ * @since 0.1.0
  */
 RedisMetrics.prototype.counter = function(eventName, options) {
   if (typeof options === 'undefined') {

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -42,9 +42,9 @@ function RedisMetrics(config) {
  *
  * @param {string} eventName - The event that we want to count for.
  * @param {Object} [options] - The options to use for the counter
- * @param {number} [options.timeGranularity] - Makes the counter use timestamps
- * which means that it can be used to measure event metrics based on time
- * intervals.
+ * @param {number} [options.timeGranularity='none'] - Makes the counter use
+ * timestamps which means that it can be used to measure event metrics based on
+ * time intervals. The default is to not use time granularities.
  * @returns {TimestampedCounter}
  */
 RedisMetrics.prototype.counter = function(eventName, options) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -56,11 +56,37 @@ var parseIntArray = function(arrayOfInts) {
 var momentRange = function(startDate, endDate, timeGranularity) {
   timeGranularity = constants.timeGranularities[timeGranularity];
   startDate = moment.utc(startDate);
-  endDate = moment.utc(endDate).add(1, 'millisecond');
+  endDate = moment.utc(endDate);
+
+  // To avoid edge case issues when adding timestamp information, the time
+  // information below the current granularity level is reset.
+  startDate.millisecond(0);
+  endDate.millisecond(0);
+  if (timeGranularity < constants.timeGranularities.second) {
+    startDate.second(0);
+    endDate.second(0);
+  }
+  if (timeGranularity < constants.timeGranularities.minute) {
+    startDate.minute(0);
+    endDate.minute(0);
+  }
+  if (timeGranularity < constants.timeGranularities.hour) {
+    startDate.hour(0);
+    endDate.hour(0);
+  }
+  if (timeGranularity < constants.timeGranularities.day) {
+    startDate.date(1);
+    endDate.date(1);
+  }
+  if (timeGranularity < constants.timeGranularities.month) {
+    startDate.month(0);
+    endDate.month(0);
+  }
 
   var momentGranularity = constants.momentGranularities[timeGranularity];
   var timestamps = [];
 
+  endDate.add(1, 'millisecond');
   for (var m = startDate; m.isBefore(endDate); m.add(1, momentGranularity)) {
     timestamps.push(moment(m));
   }

--- a/test/counter.js
+++ b/test/counter.js
@@ -25,11 +25,11 @@ describe('Counter', function() {
     metrics.client.quit(done);
   });
 
-  describe('Constructor', function() {
+  describe('constructor', function() {
 
-    it('should set sane defaults', function() {
+    it('should set some defaults', function() {
       var counter = new TimestampedCounter(metrics, 'foo');
-      expect(counter.key).to.equal('foo');
+      expect(counter.key).to.equal('c:foo');
       expect(counter.metrics).to.equal(metrics);
       expect(counter.options.timeGranularity).to.equal(0);
     });
@@ -53,7 +53,7 @@ describe('Counter', function() {
       var keys = counter.getKeys();
       expect(keys).to.be.instanceof(Array);
       expect(keys).to.have.length.above(0);
-      expect(keys).to.include('foo');
+      expect(keys).to.include('c:foo');
     });
 
     it('should return keys based on the granularity level', function() {
@@ -65,7 +65,7 @@ describe('Counter', function() {
       var keys = counter.getKeys();
       expect(keys).to.be.instanceof(Array);
       expect(keys).to.have.length(1);
-      expect(keys).to.include('foo');
+      expect(keys).to.include('c:foo');
 
       counter = new TimestampedCounter(metrics, 'foo', {
         timeGranularity: 'year'
@@ -73,8 +73,8 @@ describe('Counter', function() {
       keys = counter.getKeys();
       expect(keys).to.be.instanceof(Array);
       expect(keys).to.have.length(2);
-      expect(keys).to.include('foo');
-      expect(keys).to.include('foo:2015');
+      expect(keys).to.include('c:foo');
+      expect(keys).to.include('c:foo:2015');
 
       counter = new TimestampedCounter(metrics, 'foo', {
         timeGranularity: 'month'
@@ -82,9 +82,9 @@ describe('Counter', function() {
       keys = counter.getKeys();
       expect(keys).to.be.instanceof(Array);
       expect(keys).to.have.length(3);
-      expect(keys).to.include('foo');
-      expect(keys).to.include('foo:2015');
-      expect(keys).to.include('foo:201501');
+      expect(keys).to.include('c:foo');
+      expect(keys).to.include('c:foo:2015');
+      expect(keys).to.include('c:foo:201501');
 
       counter = new TimestampedCounter(metrics, 'foo', {
         timeGranularity: 'day'
@@ -92,10 +92,10 @@ describe('Counter', function() {
       keys = counter.getKeys();
       expect(keys).to.be.instanceof(Array);
       expect(keys).to.have.length(4);
-      expect(keys).to.include('foo');
-      expect(keys).to.include('foo:2015');
-      expect(keys).to.include('foo:201501');
-      expect(keys).to.include('foo:20150102');
+      expect(keys).to.include('c:foo');
+      expect(keys).to.include('c:foo:2015');
+      expect(keys).to.include('c:foo:201501');
+      expect(keys).to.include('c:foo:20150102');
 
       counter = new TimestampedCounter(metrics, 'foo', {
         timeGranularity: 'hour'
@@ -103,10 +103,10 @@ describe('Counter', function() {
       keys = counter.getKeys();
       expect(keys).to.be.instanceof(Array);
       expect(keys).to.have.length(5);
-      expect(keys).to.include('foo');
-      expect(keys).to.include('foo:2015');
-      expect(keys).to.include('foo:201501');
-      expect(keys).to.include('foo:2015010203');
+      expect(keys).to.include('c:foo');
+      expect(keys).to.include('c:foo:2015');
+      expect(keys).to.include('c:foo:201501');
+      expect(keys).to.include('c:foo:2015010203');
 
       counter = new TimestampedCounter(metrics, 'foo', {
         timeGranularity: 'minute'
@@ -114,11 +114,11 @@ describe('Counter', function() {
       keys = counter.getKeys();
       expect(keys).to.be.instanceof(Array);
       expect(keys).to.have.length(6);
-      expect(keys).to.include('foo');
-      expect(keys).to.include('foo:2015');
-      expect(keys).to.include('foo:201501');
-      expect(keys).to.include('foo:2015010203');
-      expect(keys).to.include('foo:201501020304');
+      expect(keys).to.include('c:foo');
+      expect(keys).to.include('c:foo:2015');
+      expect(keys).to.include('c:foo:201501');
+      expect(keys).to.include('c:foo:2015010203');
+      expect(keys).to.include('c:foo:201501020304');
 
       counter = new TimestampedCounter(metrics, 'foo', {
         timeGranularity: 'second'
@@ -126,19 +126,19 @@ describe('Counter', function() {
       keys = counter.getKeys();
       expect(keys).to.be.instanceof(Array);
       expect(keys).to.have.length(7);
-      expect(keys).to.include('foo');
-      expect(keys).to.include('foo:2015');
-      expect(keys).to.include('foo:201501');
-      expect(keys).to.include('foo:2015010203');
-      expect(keys).to.include('foo:201501020304');
-      expect(keys).to.include('foo:20150102030405');
+      expect(keys).to.include('c:foo');
+      expect(keys).to.include('c:foo:2015');
+      expect(keys).to.include('c:foo:201501');
+      expect(keys).to.include('c:foo:2015010203');
+      expect(keys).to.include('c:foo:201501020304');
+      expect(keys).to.include('c:foo:20150102030405');
     });
   });
 
   describe('incr', function() {
-    it('should call redis incr without a transaction when no time granularity is chosen', function(done) {
+    it('should call redis incrby without a transaction when no time granularity is chosen', function(done) {
       var multiSpy = sandbox.spy(metrics.client, 'multi');
-      var incrSpy = sandbox.spy(metrics.client, 'incr');
+      var incrSpy = sandbox.spy(metrics.client, 'incrby');
 
       var counter = new TimestampedCounter(metrics, 'foo');
       counter.incr().then(function() {
@@ -182,7 +182,7 @@ describe('Counter', function() {
     });
 
     it('should call the callback on error', function(done) {
-      var mock = sandbox.stub(metrics.client, 'incr')
+      var mock = sandbox.stub(metrics.client, 'incrby')
         .yields(new Error('oh no'), null);
 
       var counter = new TimestampedCounter(metrics, 'foo');
@@ -194,7 +194,7 @@ describe('Counter', function() {
     });
 
     it('should reject the promise on error', function(done) {
-      var mock = sandbox.stub(metrics.client, 'incr')
+      var mock = sandbox.stub(metrics.client, 'incrby')
         .yields(new Error('oh no'), null);
 
       var counter = new TimestampedCounter(metrics, 'foo');
@@ -244,6 +244,115 @@ describe('Counter', function() {
 
   });
 
+  describe('incrby', function() {
+    it('should call redis incrby without a transaction when no time granularity is chosen', function(done) {
+      var multiSpy = sandbox.spy(metrics.client, 'multi');
+      var incrSpy = sandbox.spy(metrics.client, 'incrby');
+
+      var counter = new TimestampedCounter(metrics, 'foo');
+      counter.incrby(2).then(function() {
+        sinon.assert.calledOnce(incrSpy);
+        sinon.assert.notCalled(multiSpy);
+        done();
+      })
+      .catch(done);
+    });
+
+    it('should call redis incr with a transaction when a time granularity is chosen', function(done) {
+      var multiSpy = sandbox.spy(metrics.client, 'multi');
+
+      var counter = new TimestampedCounter(metrics, 'foo', {
+        timeGranularity: 'year'
+      });
+
+      counter.incrby(3).then(function() {
+        sinon.assert.calledOnce(multiSpy);
+        done();
+      })
+      .catch(done);
+    });
+
+    it('should call the callback on success', function(done) {
+      var counter = new TimestampedCounter(metrics, 'foo');
+      counter.incrby(4, function(err, result) {
+        expect(err).to.be.null;
+        expect(result).to.equal(4);
+        done();
+      });
+    });
+
+    it('should resolve a promise on success', function(done) {
+      var counter = new TimestampedCounter(metrics, 'foo');
+      counter.incrby(5).then(function(result) {
+        expect(result).to.equal(5);
+        done();
+      })
+      .catch(done);
+    });
+
+    it('should call the callback on error', function(done) {
+      var mock = sandbox.stub(metrics.client, 'incrby')
+        .yields(new Error('oh no'), null);
+
+      var counter = new TimestampedCounter(metrics, 'foo');
+      counter.incrby(6, function(err, result) {
+        expect(err).to.not.be.null;
+        expect(result).to.be.null;
+        done();
+      });
+    });
+
+    it('should reject the promise on error', function(done) {
+      var mock = sandbox.stub(metrics.client, 'incrby')
+        .yields(new Error('oh no'), null);
+
+      var counter = new TimestampedCounter(metrics, 'foo');
+      counter.incrby(7).then(function() {
+        done(new Error('Should not be here'));
+      })
+      .catch(function(err) {
+        expect(err).to.not.be.null;
+        done();
+      });
+    });
+
+    it('should return a list of results from the operation', function(done) {
+      var counter = new TimestampedCounter(metrics, 'foo', {
+        timeGranularity: 'year'
+      });
+
+      counter.incrby(8).then(function(results) {
+        expect(results).to.be.instanceof(Array);
+        expect(results).to.deep.equal([8, 8]);
+        done();
+      })
+      .catch(done);
+    });
+
+    it('should work with an event object', function(done) {
+      var counter = new TimestampedCounter(metrics, 'foo');
+
+      counter.incrby(9, 'bar').then(function(result) {
+        expect(parseInt(result)).to.equal(9);
+        done();
+      })
+      .catch(done);
+    });
+
+    it('should work with an event object and time granularity', function(done) {
+      var counter = new TimestampedCounter(metrics, 'foo', {
+        timeGranularity: 'year'
+      });
+
+      counter.incrby(10, 'bar').then(function(results) {
+        expect(utils.parseIntArray(results)).to.deep.equal([10, 10]);
+        done();
+      })
+      .catch(done);
+    });
+
+  });
+
   describe('count', function() {
     it('should work with callback', function(done) {
       var mock = sandbox.mock(metrics.client)
@@ -273,6 +382,20 @@ describe('Counter', function() {
       });
     });
 
+    it('should work with time granularity, event object and callback', function(done) {
+      var mock = sandbox.mock(metrics.client)
+        .expects('zscore')
+        .once()
+        .yields(null, '10');
+
+      var counter = new TimestampedCounter(metrics, 'foo');
+      counter.count('none', 'bar', function(err, result) {
+        mock.verify();
+        expect(result).to.equal(10);
+        done(err);
+      });
+    });
+
     it('should return a single result when no arguments are given', function(done) {
       var counter = new TimestampedCounter(metrics, 'foo');
       counter.incr()
@@ -291,6 +414,40 @@ describe('Counter', function() {
           done();
         })
         .catch(done);
+    });
+
+    it('should return a single result for an event object', function(done) {
+      var counter = new TimestampedCounter(metrics, 'foo');
+      counter.incr('bar')
+        .then(function() {
+          return counter.incr('bar');
+        })
+        .then(function() {
+          return counter.incr('bar');
+        })
+        .then(function() {
+          return counter.count('total', 'bar');
+        })
+        .then(function(result) {
+          // Counter has been incremented 3 times.
+          expect(result).to.equal(3);
+          done();
+        })
+        .catch(done);
+    });
+
+    it('should return 0 when the key does not exist (callback)', function(done) {
+      var mock = sandbox.mock(metrics.client)
+        .expects('get')
+        .once()
+        .yields(null, null);
+
+      var counter = new TimestampedCounter(metrics, 'foo');
+      counter.count(function(err, result) {
+        mock.verify();
+        expect(result).to.equal(0);
+        done(err);
+      })
     });
 
     it('should return 0 when the key does not exist (promise)', function(done) {
@@ -336,6 +493,34 @@ describe('Counter', function() {
         })
         .catch(done);
     });
+
+    it('should return a count for a specific time granularity and event object', function(done) {
+      var counter = new TimestampedCounter(metrics, 'foo', {
+        timeGranularity: 'year'
+      });
+
+      // Increment in 2014 and 2015
+      // Total should be 2 but year should be 1.
+
+      var clock = sandbox.useFakeTimers(new Date('2014-02-01').getTime());
+      counter.incr('bar')
+        .then(function() {
+          clock.tick(1000*60*60*24*365);
+          return counter.incr('bar');
+        })
+        .then(function() {
+          return counter.count('none', 'bar');
+        })
+        .then(function(result) {
+          expect(result).to.equal(2);
+          return counter.count('year', 'bar');
+        })
+        .then(function(result) {
+          expect(result).to.equal(1);
+          done();
+        })
+        .catch(done);
+    });
   });
 
   describe('countRange', function() {
@@ -370,6 +555,44 @@ describe('Counter', function() {
 
           // Check callback
           counter.countRange('year', start, end, function(err, res) {
+            expect(res).to.deep.equal(expected);
+            done();
+          });
+        })
+        .catch(done);
+    });
+
+    it('should return a range of count for an event object', function(done) {
+      var counter = new TimestampedCounter(metrics, 'foo', {
+        timeGranularity: 'year'
+      });
+
+      // Increment 2014 once and 2015 twice
+
+      var start = moment.utc({ year: 2014 });
+      var end = moment.utc({ year: 2015 });
+      var expected = {};
+      expected[start.format()] = 1;
+      expected[end.format()] = 2;
+
+      var clock = sandbox.useFakeTimers(new Date('2014-02-01').getTime());
+      counter.incr('bar')
+        .then(function() {
+          clock.tick(1000*60*60*24*365);
+          return counter.incr('bar');
+        })
+        .then(function() {
+          return counter.incr('bar');
+        })
+        .then(function() {
+          return counter.countRange('year', start, end, 'bar');
+        })
+        .then(function(result) {
+          // Check promise
+          expect(result).to.deep.equal(expected);
+
+          // Check callback
+          counter.countRange('year', start, end, 'bar', function(err, res) {
             expect(res).to.deep.equal(expected);
             done();
           });
@@ -438,6 +661,37 @@ describe('Counter', function() {
 
           // Check callback
           counter.countRange('year', start, end, function(err, res) {
+            expect(res).to.deep.equal(expected);
+            done();
+          });
+        })
+        .catch(done);
+    });
+
+    it('should return 0 for counters where no data is registed for the event object', function(done) {
+      var counter = new TimestampedCounter(metrics, 'foo', {
+        timeGranularity: 'year'
+      });
+
+      // Increment 2014 once.
+
+      var start = moment.utc({ year: 2014 });
+      var end = moment.utc({ year: 2015 });
+      var expected = {};
+      expected[start.format()] = 1;
+      expected[end.format()] = 0;
+
+      var clock = sandbox.useFakeTimers(new Date('2014-02-01').getTime());
+      counter.incr('bar')
+        .then(function() {
+          return counter.countRange('year', start, end, 'bar');
+        })
+        .then(function(result) {
+          // Check promise
+          expect(result).to.deep.equal(expected);
+
+          // Check callback
+          counter.countRange('year', start, end, 'bar', function(err, res) {
             expect(res).to.deep.equal(expected);
             done();
           });

--- a/test/counter.js
+++ b/test/counter.js
@@ -7,7 +7,8 @@ var chai = require('chai'),
     redis = require('redis'),
     moment = require('moment'),
     RedisMetrics = require('../lib/metrics'),
-    TimestampedCounter = require('../lib/counter');
+    TimestampedCounter = require('../lib/counter'),
+    utils = require('../lib/utils');
 
 describe('Counter', function() {
 
@@ -149,11 +150,10 @@ describe('Counter', function() {
     });
 
     it('should call redis incr with a transaction when a time granularity is chosen', function(done) {
-      var multi
       var multiSpy = sandbox.spy(metrics.client, 'multi');
 
       var counter = new TimestampedCounter(metrics, 'foo', {
-        timeGranularity: 1
+        timeGranularity: 'year'
       });
 
       counter.incr().then(function() {
@@ -209,12 +209,34 @@ describe('Counter', function() {
 
     it('should return a list of results from the operation', function(done) {
       var counter = new TimestampedCounter(metrics, 'foo', {
-        timeGranularity: 1
+        timeGranularity: 'year'
       });
 
       counter.incr().then(function(results) {
         expect(results).to.be.instanceof(Array);
         expect(results).to.deep.equal([1, 1]);
+        done();
+      })
+      .catch(done);
+    });
+
+    it('should work with an event object', function(done) {
+      var counter = new TimestampedCounter(metrics, 'foo');
+
+      counter.incr('bar').then(function(result) {
+        expect(parseInt(result)).to.equal(1);
+        done();
+      })
+      .catch(done);
+    });
+
+    it('should work with an event object and time granularity', function(done) {
+      var counter = new TimestampedCounter(metrics, 'foo', {
+        timeGranularity: 'year'
+      });
+
+      counter.incr('bar').then(function(results) {
+        expect(utils.parseIntArray(results)).to.deep.equal([1, 1]);
         done();
       })
       .catch(done);


### PR DESCRIPTION
Add support for an optional event object when incrementing a counter. The event object is internally stored in Redis using a sorted set.

The event object is useful for keeping counting a single event in a specific context. For example, for a page view counter we might want to keeps track of the count for individual pages.
