### PR TITLE
Automatic expiration of counter keys

### DIFF
--- a/docs/counting.md
+++ b/docs/counting.md
@@ -1,0 +1,223 @@
+So you want to keep track of your page views? Then you might want to use a
+counter in Redis.
+
+`redis-metrics` provides a simple counter through the {@link
+TimestampedCounter} class. The counter object currently has two main
+functionalities:
+
+* Incrementing the counter
+* Reporting the count
+
+This is really simple, but we are not trying to re-invent the wheel here, just
+make it a bit rounder. Besides basic counting, the {@link TimestampedCounter}
+offers a bit more functionality... some extra sugar if you will. Let's take a
+look.
+
+#### Creating a counter
+
+Usually, a counter is created with the {@link RedisMetrics#counter} function.
+Let's start by creating a counter that is capable of reporting counts with a
+time granularity of one hour:
+
+```javascript
+var metrics = require('redis-metrics')();
+var myCounter = metrics.counter('pageview', {
+  timeGranularity: 'hour',
+  expireKeys: true
+};
+```
+
+Here, we are passing an options object explicitly to the counter. This is
+useful when we want different settings for different counters. We can also
+specify some default counter settings on the metrics module itself:
+
+```javascript
+var metrics = require('redis-metrics')({
+  counterOptions: {
+    timeGranularity: 'hour',
+    expireKeys: true
+  }
+});
+
+// Will use the counterOptions object because no options are provided.
+var myCounter = metrics.counter('pageview');
+```
+
+#### Incrementing a counter
+
+The counter can be incremented in two ways, using {@link
+TimestampedCounter#incr|incr} or {@link TimestampedCounter#incrby|incrby}:
+
+```javascript
+// Increment by 1
+myCounter.incr(function(err, result) {
+  console.log(result);
+});
+
+// Increment by 5
+myCounter.incrby(5, function(err, result) {
+  console.log(result);
+});
+```
+
+The `err` and `result` parameters contain the answer from Redis.
+
+This looks and feels as if we are incrementing a normal Redis counter. Behind
+the scenes, that is exactly what is happening but with a slight twist. Since we
+have chosen a time granularity of an hour, more than one counter is being
+incremented for various timestamps. This does give some extra overhead, but it
+makes it very easy and fast to retrieve a count for a specific period.
+
+#### Fetching a count
+
+Since our counter has a time granularity of an hour, we can now answer
+questions such as: "How many page views do I have so far today?" and "How many
+page views do I have so far this hour?":
+
+```javascript
+// Number of page views today.
+myCounter.count('day', function(err, result) {
+  console.log(result);
+});
+
+// Number of page views this hour.
+myCounter.count('hour', function(err, result) {
+  console.log(result);
+});
+```
+
+Of course, we can also get the total number of page views:
+
+```javascript
+// Number of page views in total.
+myCounter.count(function(err, result) {
+  console.log(result);
+});
+```
+
+In all of the above methods `result` is single integer.
+
+#### Fetching a count for a time range
+
+Fetching a single count for the current time is useful, but often it makes
+sense to view metrics over a period of time. Let's ask the counter "What is my
+page view count for the last 24 hours until now?" using the {@link
+TimestampedCounter#countRange|countRange} function:
+
+```javascript
+// Moment is nice and easy for dates so we'll just use that here.
+var moment = require('moment');
+var yesterday = moment().add(-24, 'hours');
+
+// No end time specified so use the current time will be used.
+myCounter.countRange('hour', yesterday, function(err, result) {
+  console.log(result);
+});
+
+// Use explicit end time.
+var now = moment();
+myCounter.countRange('hour', yesterday, now, function(err, result) {
+  console.log(result);
+});
+```
+
+The start and end parameters can be anything that that the
+[`moment(...)`](http://momentjs.com/docs/#/parsing/) constructor understands.
+
+When requesting a time range, `result` is an object with ISO-formatted
+timestamps as keys and the count for each timestamp as the values. For the
+above query, `result` could thus be:
+
+```json
+{
+  '2015-04-15T11:00:00+00:00': 788,
+  '2015-04-15T12:00:00+00:00': 237,
+  ...
+  '2015-04-16T10:00:00+00:00': 519,
+  '2015-04-16T11:00:00+00:00': 231
+}
+```
+
+**Warning**: The timestamps are *always* UTC.
+
+### Using an event object
+
+For many use cases, it makes sense to track an event in a more specific
+context. For example, you might want to track the individual page views of
+specific pages in your app such as "/about" and "/contact". You could create
+separate counters for each of these pages, but for this specific use case, you
+might want to use "event objects".
+
+Using the feature is easy and best shown by example. We can use the same page
+view counter from before:
+
+```javascript
+// Increment the page view counter for the event object "/contact".
+myCounter.incr('/contact', function(err, result) {
+  console.log(result);
+});
+
+// Increment the page view counter for the event object "/contact".
+myCounter.incr('/about', function(err, result) {
+  console.log(result);
+});
+```
+
+When using an event object, internally in Redis the event objects are
+incremented in a sorted set on the given key. After calling the two operations
+above, we will thus have a Redis key called "pageview" which contains a [sorted
+set](http://redis.io/topics/data-types) with "/about" and "/contact".
+Reporting a count for an event object is similar to before:
+
+```javascript
+// Number of page views today for about page
+myCounter.count('day', '/about', function(err, result) {
+  console.log(result);
+});
+
+// Number of page views this hour for the contact page
+myCounter.count('hour', '/contact', function(err, result) {
+  console.log(result);
+});
+```
+
+Time ranges work as well for event objects. For example, I have this question
+"Show me the page view count for the last 24 hours for the /about page" and
+here is the answer:
+
+```javascript
+// Moment is nice and easy for dates so we'll just use that here.
+var moment = require('moment');
+var yesterday = moment().add(-24, 'hours');
+var now = moment();
+
+myCounter.countRange('hour', yesterday, now, '/about', function(err, result) {
+  console.log(result);
+});
+```
+
+The output of the above query is similar to before:
+
+```json
+{
+  '2015-04-15T11:00:00+00:00': 12,
+  '2015-04-15T12:00:00+00:00': 67,
+  ...
+  '2015-04-16T10:00:00+00:00': 93,
+  '2015-04-16T11:00:00+00:00': 32
+}
+```
+
+**Warning**: When using {@link TimestampedCounter#countRange|countRange} for
+event objects, the end date is mandatory.
+
+#### Top N for event objects
+
+Because event objects are stored in [sorted
+sets](http://redis.io/topics/data-types), we automatically get some benefits
+from Redis. For example, it is very easy to get a list of the top 10 visited
+pages for our counter or even a sorted list of all pages by page count.
+
+Since we are at a very early stage in the project, this feature has not been
+added yet, but it will in the near future because it fits our own use cases
+very well. Stay tuned :-)

--- a/docs/structure.json
+++ b/docs/structure.json
@@ -1,0 +1,5 @@
+{
+  "counting": {
+    "title": "Counting stuff"
+  }
+}

--- a/jsdoc.json
+++ b/jsdoc.json
@@ -9,6 +9,7 @@
     "plugins/markdown"
   ],
   "opts": {
+    "tutorials": "docs/",
     "destination": "out/",
     "recurse": true,
     "readme": "README.md"

--- a/jsdoc.json
+++ b/jsdoc.json
@@ -2,6 +2,12 @@
   "source": {
     "include": [ "lib/" ]
   },
+  "templates": {
+    "cleverLinks": true
+  },
+  "plugins": [
+    "plugins/markdown"
+  ],
   "opts": {
     "destination": "out/",
     "recurse": true,

--- a/lib/counter.js
+++ b/lib/counter.js
@@ -4,14 +4,48 @@ var _ = require('lodash'),
     Q = require('q'),
     moment = require('moment'),
     timeGranularities = require('./constants').timeGranularities,
-    utils = require('./utils');
+    utils = require('./utils'),
+    lua = require('./lua');
+
+// The default expiration times aim at having less than 800 counters for a
+// given counter key (event) since the counter keys are stored with a specific
+// timestamp. For example, second-based counters expire after 10 minutes which
+// means that there will be 600 counter keys in the worst-case for a single
+// event.
+var defaultExpiration = {
+  total: -1,
+  year: -1,
+  month:  10 * 365 * 24 * 60 * 60, // 10 years = 120 counters worst-case
+  day:  2 * 365 * 24 * 60 * 60,    // 2 years = 730 counters worst-case
+  hour:  31 * 24 * 60 * 60,        // 31 days = 744 counters worst-case
+  minute:  12 * 60 * 60,           // 12 hours = 720 counters worst-case
+  second:  10 * 60                 // 10 minutes = 600 counters worst-case
+};
+// BTW, good luck keeping your Redis server around for 10 years :-)
+
+// Translate the "nice looking expiration times above to "real" keys that
+// correspond to time granularities.
+_.keys(defaultExpiration).forEach(function(key) {
+  var newKey = timeGranularities[key];
+  var value = defaultExpiration[key];
+  delete defaultExpiration[key];
+  defaultExpiration[newKey] = value;
+});
 
 var defaults = {
-  timeGranularity: timeGranularities.none
+  timeGranularity: timeGranularities.none,
+  expireKeys: true,
+  expiration: defaultExpiration
 };
 
 var momentFormat = 'YYYYMMDDHHmmss';
 
+/**
+ * Convert the given granularity level into the internal representation (a
+ * number).
+ * @returns {module:constants~timeGranularities}
+ * @private
+ */
 var parseTimeGranularity = function(timeGranularity) {
   timeGranularity = timeGranularities[timeGranularity];
   if (timeGranularity) return timeGranularity;
@@ -34,9 +68,6 @@ var createRangeParser = function(keyRange) {
 /**
  * A timestamped event counter.
  *
- * This constructor is usually not called directly but through the
- * {@link RedisMetrics#counter} function.
- *
  * The timestamped counter stores one or more Redis keys based on the given
  * event name and time granularity appends a timestamp to the key before
  * storing the key in Redis. The counter can then report an overall aggregated
@@ -47,17 +78,29 @@ var createRangeParser = function(keyRange) {
  * just like a global counter for the given key, i.e. events will not be
  * timestamped.
  *
+ * **Notice**: The constructor for this class is usually not called directly
+ * but through the {@link RedisMetrics#counter} function.
+ *
  * @param {RedisMetrics} metrics - An instance of a RedisMetrics client.
  * @param {string} key - The base key to use for this counter.
  * @param {Object} options - The options to use for this counter. The available
- * options are specified in {@link RedisMetrics#counter}.
+ *   options are specified in {@link RedisMetrics#counter}.
  * @class
  */
 function TimestampedCounter(metrics, key, options) {
   this.metrics = metrics;
   this.key = 'c:' + key; // Pre-prend c to indicate it's a counter.
   this.options = options || {};
-  _.defaults(this.options, defaults);
+  _.defaults(this.options, _.cloneDeep(defaults));
+
+  // Translate the expiration keys of the options.
+  var _this = this;
+  _.keys(this.options.expiration).forEach(function(key) {
+    var newKey = timeGranularities[key];
+    var value = _this.options.expiration[key];
+    delete _this.options.expiration[key];
+    _this.options.expiration[newKey] = value;
+  });
 
   this.options.timeGranularity =
     parseTimeGranularity(this.options.timeGranularity);
@@ -83,6 +126,42 @@ TimestampedCounter.prototype.getKeys = function() {
     keys.push(this.key + ':' + now.slice(0, i*2+2));
   }
   return keys;
+};
+
+/**
+ * Finds the configured time to live for the given key.
+ * @param {string} key - The full key (including timestamp) for the key to
+ *   determine the ttl for.
+ * @returns {number} Number of seconds that the key should live.
+ */
+TimestampedCounter.prototype.getKeyTTL = function(key) {
+  if (!this.options.expireKeys) return -1;
+
+  var timePart = key.replace(this.key, '').split(':')[1] || '';
+  var timeGranularity = timeGranularities.none;
+  switch (timePart.length) {
+    case 4:
+      timeGranularity = timeGranularities.year;
+      break;
+    case 6:
+      timeGranularity = timeGranularities.month;
+      break;
+    case 8:
+      timeGranularity = timeGranularities.day;
+      break;
+    case 10:
+      timeGranularity = timeGranularities.hour;
+      break;
+    case 12:
+      timeGranularity = timeGranularities.minute;
+      break;
+    case 14:
+      timeGranularity = timeGranularities.second;
+      break;
+  }
+  var ttl = this.options.expiration[timeGranularity];
+  if (typeof ttl === 'undefined') ttl = defaultExpiration[timeGranularity];
+  return ttl;
 };
 
 /**
@@ -129,23 +208,44 @@ TimestampedCounter.prototype.incrby = function(amount, eventObj, callback) {
   return deferred.promise;
 };
 
+var incrSingle = function(client, key, amount, eventObj, ttl, cb) {
+  if (eventObj) {
+    key += ':z';
+
+    if (ttl > 0) {
+      if (cb) client.eval(lua.zincrbyExpire, 1, key, amount, eventObj, ttl, cb);
+      else client.eval(lua.zincrbyExpire, 1, key, amount, eventObj, ttl);
+    }
+    else {
+      if (cb) client.zincrby(key, amount, eventObj, cb);
+      else client.zincrby(key, amount, eventObj);
+    }
+
+  } else { // No event object
+
+    if (ttl > 0) {
+      if (cb) client.eval(lua.incrbyExpire, 1, key, amount, ttl, cb);
+      else client.eval(lua.incrbyExpire, 1, key, amount, ttl);
+    }
+    else {
+      if (cb) client.incrby(key, amount, cb);
+      else client.incrby(key, amount);
+    }
+  }
+};
+
 TimestampedCounter.prototype._incrby = function(amount, eventObj, cb) {
   var keys = this.getKeys();
   // Optimize for the case where there is only a single key to increment.
   if (keys.length === 1) {
-    if (eventObj) {
-      this.metrics.client.zincrby(keys[0] + ':z', amount, eventObj, cb);
-    } else {
-      this.metrics.client.incrby(keys[0], amount, cb);
-    }
+    var ttl = this.getKeyTTL(keys[0]);
+    incrSingle(this.metrics.client, keys[0], amount, eventObj, ttl, cb);
   } else {
     var multi = this.metrics.client.multi();
+    var _this = this;
     keys.forEach(function(key) {
-      if (eventObj) {
-        multi.zincrby(key + ':z', amount, eventObj);
-      } else {
-        multi.incrby(key, amount);
-      }
+      var ttl = _this.getKeyTTL(key);
+      incrSingle(multi, key, amount, eventObj, ttl);
     });
     multi.exec(cb);
   }

--- a/lib/counter.js
+++ b/lib/counter.js
@@ -258,7 +258,7 @@ TimestampedCounter.prototype._incrby = function(amount, eventObj, cb) {
  * value at the given granularity level. Effectively, this provides a single
  * answer to questions such as "what is the count for the current day".
  *
- * Notice that counts cannot be returned for a given time granularity if it was
+ * **Notice**: Counts cannot be returned for a given time granularity if it was
  * not incremented at this granularity level in the first place.
  *
  * @example
@@ -316,7 +316,7 @@ TimestampedCounter.prototype._count = function(timeGranularity, eventObj, cb) {
 };
 
 /**
- * Returns a object mapping timestamps to counts in the given time range at a
+ * Returns an object mapping timestamps to counts in the given time range at a
  * specific time granularity level.
  *
  * Notice: This function does not make sense for the "none" time granularity.

--- a/lib/lua.js
+++ b/lib/lua.js
@@ -1,0 +1,12 @@
+'use strict';
+
+/**
+ * Useful for lua scripts for Redis
+ */
+
+module.exports = {
+  /*jslint maxlen: 500 */
+  /*jslint quotmark: false */
+  incrbyExpire: "local v = redis.call('INCRBY', KEYS[1], ARGV[1]) if tostring(v) == tostring(ARGV[1]) then redis.call('EXPIRE', KEYS[1], ARGV[2]) end return v",
+  zincrbyExpire: "local v = redis.call('ZINCRBY', KEYS[1], ARGV[1], ARGV[2]) if tostring(v) == tostring(ARGV[1]) then redis.call('EXPIRE', KEYS[1], ARGV[3]) end return v"
+};

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -43,8 +43,10 @@ function RedisMetrics(config) {
  * @param {string} eventName - The event that we want to count for.
  * @param {Object} [options] - The options to use for the counter
  * @param {number} [options.timeGranularity='none'] - Makes the counter use
- * timestamps which means that it can be used to measure event metrics based on
- * time intervals. The default is to not use time granularities.
+ *   timestamps which means that it can be used to measure event metrics based
+ *   on time intervals. The default is to not use time granularities.
+ * @param {boolean} [options.expireKeys=true] - Automatically expire keys.
+ *   Useful for high time granularity levels to preserve memory.
  * @returns {TimestampedCounter}
  * @since 0.1.0
  */

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,6 +2,7 @@
 
 /**
  * @module utils
+ * @private
  */
 
 var _ = require('lodash'),

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "redis": "^0.12.1"
   },
   "devDependencies": {
+    "async": "^0.9.0",
     "chai": "^2.2.0",
     "istanbul": "^0.3.13",
     "jsdoc": "^3.3.0-beta3",

--- a/test/metrics.js
+++ b/test/metrics.js
@@ -72,21 +72,21 @@ describe('Metric main', function() {
 
     it('should pass the options object to the counter constructor', function() {
       var options = {
-        timeGranularity: 'hour'
+        timeGranularity: 1
       };
       var counter = metrics.counter('foo', options);
-      expect(counter.options).to.equal(options);
+      expect(counter.options.timeGranularity).to.equal(1);
     });
 
     it('should use the default counter options when none are provided', function() {
       metrics = new RedisMetrics({
         counterOptions: {
-          timeGranularity: 3
+          timeGranularity: 2
         }
       });
 
       var counter = metrics.counter('foo');
-      expect(counter.options).to.deep.equal(metrics.config.counterOptions);
+      expect(counter.options.timeGranularity).to.equal(2);
     });
   });
 


### PR DESCRIPTION
This PR adds support for automatic expiration of counter keys. Keys are set to expire by default and the expiration time depends on the granularity of the counter. For example, total counters never expire while counters per second expire after only 10 minutes.
