### PR TITLE
Prevent endless loop for countRange

### DIFF
--- a/lib/counter.js
+++ b/lib/counter.js
@@ -66,6 +66,17 @@ var createRangeParser = function(keyRange) {
 };
 
 /**
+ * Creates a function that parses a list of Redis results and returns the total.
+ * @returns {function}
+ * @private
+ */
+var createRangeTotalParser = function() {
+  return function(results) {
+    return _.sum(utils.parseIntArray(results));
+  };
+};
+
+/**
  * A timestamped event counter.
  *
  * The timestamped counter stores one or more Redis keys based on the given
@@ -351,6 +362,22 @@ TimestampedCounter.prototype.countRange = function(
   }
   if (eventObj) eventObj = String(eventObj);
 
+  // Save the report time granularity because it might change.
+  var reportTimeGranularity = timeGranularity;
+
+  // If the range granularity is total, fall back to the granularity specified
+  // at the counter level and then add the numbers together when parsing the
+  // result.
+  if (timeGranularity === timeGranularities.total) {
+    timeGranularity = this.options.timeGranularity;
+
+    // If the rangeGranularity is still total, it does not make sense to report
+    // a range for the counter and we throw an error.
+    if (timeGranularity === timeGranularities.total) {
+      throw new Error('total granularity not supported for this counter');
+    }
+  }
+
   var momentRange = utils.momentRange(startDate, endDate, timeGranularity);
   var _this = this;
   var keyRange = [];
@@ -368,8 +395,9 @@ TimestampedCounter.prototype.countRange = function(
   });
 
   var deferred = Q.defer();
-  var rangeParser = createRangeParser(momentKeyRange);
-  var cb = utils.createRedisCallback(deferred, callback, rangeParser);
+  var parser = reportTimeGranularity === timeGranularities.total ?
+    createRangeTotalParser() : createRangeParser(momentKeyRange);
+  var cb = utils.createRedisCallback(deferred, callback, parser);
 
   this._countRange(keyRange, eventObj, cb);
 


### PR DESCRIPTION
This commit fixes an issue where countRange goes into an endless loop if the timeGranularity is set to total or none. Instead, the reported numbers are summed together if possible.
