### PR TITLE
Add a "namespace" option to TimestampedCounter

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,14 @@ myCounter.countRange('day', thirtyDaysAgo, now)
 // the hour.
 ```
 
+Redis Namespace
+----
+By default keys are stored in Redis as `c:{name}:{period}`. If you prefer to use a different Redis namespace than `c`, you can pass this in as an option:
+```
+var myCounter = metrics.counter('pageview', { timeGranularity: 'hour', namespace: 'stats' });`
+```
+
+
 Test
 ----
 Run tests including code coverage:

--- a/lib/counter.js
+++ b/lib/counter.js
@@ -33,6 +33,7 @@ _.keys(defaultExpiration).forEach(function(key) {
 });
 
 var defaults = {
+  namespace: 'c',
   timeGranularity: timeGranularities.none,
   expireKeys: true,
   expiration: defaultExpiration
@@ -99,10 +100,11 @@ var createRangeTotalParser = function() {
  * @class
  */
 function TimestampedCounter(metrics, key, options) {
-  this.metrics = metrics;
-  this.key = 'c:' + key; // Pre-prend c to indicate it's a counter.
   this.options = options || {};
   _.defaults(this.options, _.cloneDeep(defaults));
+
+  this.metrics = metrics;
+  this.key = this.options.namespace + ':' + key; // Pre-prend c to indicate it's a counter.
 
   // Translate the expiration keys of the options.
   var _this = this;

--- a/test/counter.js
+++ b/test/counter.js
@@ -33,6 +33,15 @@ describe('Counter', function() {
       expect(counter.key).to.equal('c:foo');
       expect(counter.options.timeGranularity).to.equal(0);
       expect(counter.options.expireKeys).to.be.true;
+      expect(counter.options.namespace).to.equal('c');
+    });
+
+    it('should respect the passed namespace in the key', function () {
+      var counter = new TimestampedCounter(metrics, 'foo', {
+        namespace: 'stats'
+      });
+      expect(counter.key).to.equal('stats:foo');
+      expect(counter.options.namespace).to.equal('stats');
     });
 
     it('should reset an incorrect time granularity to "none"', function() {


### PR DESCRIPTION
This commit adds a "namespace" option to the TimestampedCounter, such that the stats are stored under `{namespace}:{name}:{period}` with the default namespace of "c" behaving exactly as it did before.

This is because we try to keep our redis database descriptive and easy to browse.

I've added tests and some documentation covering this change also.
