### PR TITLE
Remove client restriction, clarify error handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ node_js:
 - '0.12'
 - '0.10'
 services:
-  - redis-server
+- redis-server
 deploy:
   provider: npm
   api_key:
@@ -14,7 +14,7 @@ deploy:
     secure: ReldtI/qWiezDWylhENP+QWnyTlVOQgfdUoCmfZ+3yt70hdRMZeFF2Lwhp31Lzlf+8KmSlw1TGPTyTHqv1SE/artFuGr1+GuDp6bC17aBsSx9G5bc/QpQtL+xW4f+3/kS+Zubxa4D6ajxMa+lfR0qPAhBdso5vjXyypCmp4CaOU=
   on:
     tags: true
-    repo: Receiptful/redis-metrics
+    repo: getconversio/redis-metrics
 notifications:
   slack:
-    secure: PiOgA/Hj5VRI91GASfOV31O2Ig+3kvN5AiyX8OKLADXgq/n/g1Aixavv5PgRwN5MuqAk4T/mh5ZYcTyJr18Ke1M1o5bvwJ8171BhfFPiBpPrzK4VA24KE4LA729HIBLq/fzksx0YQTkfIE5xmt8u3CG0usrn7P94gYJAcAsVvgQ=
+    secure: EBNkXvxS4CvMUzzLLDDraZlj0mpq/cQ809emxZKG/7Ld7j/E0SDqbngegFSTT1JsJpaIiyF/9eV9nkgqs8QYIz0QMajobKaSQI/u2UTxyWXuH6r99xJaWDIFIhl6mCxYh1dqfbEJUMAAIAsUW3HCxfZTNyp0NqEVu3+YXcvExjc=

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ In a sense, the libary tries to provide sugar-coated method calls for storing
 and fetching Redis data to report counts and trends. The first design goal is to
 make counting simpler.
 
-Read on below or read more on the [documentation site](http://receiptful.github.io/redis-metrics/).
+Read on below or read more on the [documentation site](http://getconversio.github.io/redis-metrics/).
 
 Install
 -------
@@ -28,6 +28,9 @@ Basic counter:
 // Create an instance
 var RedisMetrics = require('redis-metrics');
 var metrics = new RedisMetrics();
+
+// If you need to catch uncaught exceptions, add an error handler to the client.
+metrics.client.on('error', function(err) { ... });
 
 // Create a counter for a "pageview" event and increment it three times.
 var myCounter = metrics.counter('pageview');
@@ -52,6 +55,9 @@ Time-aware counter.
 // Create an instance
 var RedisMetrics = require('redis-metrics');
 var metrics = new RedisMetrics();
+
+// If you need to catch uncaught exceptions, add an error handler to the client.
+metrics.client.on('error', function(err) { ... });
 
 // Use the timeGranularity option to specify how specific the counter should be
 // when incrementing.
@@ -116,4 +122,4 @@ Documentation
 The internal module documentation is based on [jsdoc](http://usejsdoc.org) and
 can be generated with:
 
-    $ npm run-script docs
+    $ npm run docs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '2'
+
+services:
+  redis:
+    image: redis:3
+  dev:
+    image: node:6
+    command: npm test
+    volumes:
+     - .:/usr/src/app
+    working_dir: /usr/src/app
+    depends_on:
+     - redis
+    environment:
+     - REDIS_HOST=redis
+     - REDIS_PORT=6379

--- a/docs/counting.md
+++ b/docs/counting.md
@@ -20,7 +20,8 @@ Let's start by creating a counter that is capable of reporting counts with a
 time granularity of one hour:
 
 ```javascript
-var metrics = require('redis-metrics')();
+var RedisMetrics = require('redis-metrics');
+var metrics = new RedisMetrics();
 var myCounter = metrics.counter('pageview', {
   timeGranularity: 'hour',
   expireKeys: true
@@ -32,7 +33,8 @@ useful when we want different settings for different counters. We can also
 specify some default counter settings on the metrics module itself:
 
 ```javascript
-var metrics = require('redis-metrics')({
+var RedisMetrics = require('redis-metrics');
+var metrics = new RedisMetrics({
   counterOptions: {
     timeGranularity: 'hour',
     expireKeys: true

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -5,14 +5,26 @@ var redis = require('redis'),
     TimestampedCounter = require('./counter');
 
 /**
- * A simple metrics utility for Redis.
+ * A simple metrics utility for Redis. Creates a connection to Redis using the
+ * given options or an already-connected Redis client.
+ *
+ * The `client` does not set up a catch-all error handler. If you rely on
+ * handling uncaught exceptions, it's a good idea to create an error handler
+ * (see the example).
  *
  * @param {Object} [config] - configuration options
- * @param {string} [config.host] - The Redis host to use.
- * @param {string} [config.port] - The Redis port to use.
+ * @param {Object} [config.client] - An existing redis client.  The only
+ * fully-supported client is
+ * {@link https://www.npmjs.com/package/redis|node_redis}
+ * @param {String} [config.host] - The Redis host to use.
+ * @param {String} [config.port] - The Redis port to use.
  * @param {Object} [config.redisOptions] - The Redis options to use.
  * @param {Object} [config.counterOptions] - Default counter options to use if
  * none are provided when creating a counter. See {@link RedisMetrics#counter}
+ * @example
+ * var metrics = new RedisMetrics();
+ * metrics.client.on('error', console.error);
+ * metrics.counter('coolCounter').incr(1);
  * @class
  */
 function RedisMetrics(config) {
@@ -22,14 +34,6 @@ function RedisMetrics(config) {
   this.config = config = config || {};
 
   if (this.config.client) {
-    if (!(this.config.client instanceof redis.RedisClient)) {
-      throw new Error(
-        'The client option is expected to be a RedisClient instance, got ' +
-        this.config.client.constructor.name +
-        ' instead.'
-      );
-    }
-
     this.client = this.config.client;
   } else if (config.host && config.port) {
     var redisOptions = config.redisOptions || {};
@@ -37,6 +41,10 @@ function RedisMetrics(config) {
   } else if (config.redisOptions) {
     this.client = redis.createClient(config.redisOptions);
   } else {
+    /**
+     * The client connection
+     * @member {Object}
+     * **/
     this.client = redis.createClient();
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Receiptful/redis-metrics.git"
+    "url": "https://github.com/getconversio/redis-metrics.git"
   },
   "bugs": {
-    "url": "https://github.com/Receiptful/redis-metrics/issues"
+    "url": "https://github.com/getconversio/redis-metrics/issues"
   },
   "keywords": [
     "redis",
@@ -24,7 +24,7 @@
     "counter",
     "trend"
   ],
-  "author": "Receiptful <info@receiptful.com> (https://receiptful.com)",
+  "author": "Conversio <dev@conversio.com> (https://conversio.com)",
   "license": "MIT",
   "dependencies": {
     "jscs": "^2.11.0",
@@ -36,8 +36,9 @@
   "devDependencies": {
     "async": "^0.9.0",
     "chai": "^2.2.0",
+    "ioredis": "^2.5.0",
     "istanbul": "^0.3.13",
-    "jsdoc": "^3.3.0-beta3",
+    "jsdoc": "^3.4.3",
     "jshint": "^2.7.0",
     "mocha": "^2.2.4",
     "sinon": "^1.14.1"

--- a/test/counter.js
+++ b/test/counter.js
@@ -3,6 +3,7 @@
 var chai = require('chai'),
   sinon = require('sinon'),
   moment = require('moment'),
+  IORedis = require('ioredis'),
   RedisMetrics = require('../lib/metrics'),
   TimestampedCounter = require('../lib/counter'),
   utils = require('../lib/utils');
@@ -15,7 +16,17 @@ describe('Counter', function() {
   var sandbox;
   beforeEach(function(done) {
     sandbox = sinon.sandbox.create();
-    metrics = new RedisMetrics();
+    var host = process.env.REDIS_HOST || 'localhost';
+    var port = process.env.REDIS_PORT || 6379;
+    if (process.env.USE_IOREDIS) {
+      var client = new IORedis(port, host);
+      metrics = new RedisMetrics({ client: client });
+    } else {
+      metrics = new RedisMetrics({
+        host: host,
+        port: port
+      });
+    }
     metrics.client.flushall(done);
   });
 

--- a/test/metrics.js
+++ b/test/metrics.js
@@ -26,7 +26,8 @@ describe('Metric main', function() {
     });
 
     it('should create an instance without new keyword', function() {
-      var metrics = new RedisMetrics();
+      // This is not encouraged though :-)
+      var metrics = require('../lib/metrics')();
       expect(metrics).to.be.instanceof(RedisMetrics);
     });
 
@@ -69,18 +70,6 @@ describe('Metric main', function() {
 
       new RedisMetrics({ client: client });
       mock.verify();
-    });
-
-    it('should throw an error if the client is not a redis object', function() {
-      var client = { };
-
-      try {
-        new RedisMetrics({ client: client });
-      } catch (e) {
-        return;
-      }
-
-      throw new Error('This should never be called.');
     });
   });
 


### PR DESCRIPTION
This commit removes the restriction on client-type when using an
existing client.

Also updates some links and adds a docker-compose file for convenience.

Related to #13 and hinted at in #14 