### PR TITLE
Update to ES6-style, use native Promise

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -14,5 +14,6 @@
     "disallowSpacesInAnonymousFunctionExpression": {
         "beforeOpeningRoundBrace": true
     },
-    "requireSpacesInAnonymousFunctionExpression": null
+    "requireSpacesInAnonymousFunctionExpression": null,
+    "maximumLineLength": 100
 }

--- a/.jshintrc
+++ b/.jshintrc
@@ -33,8 +33,8 @@
   // Prohibit use of a variable before it is defined.
   "latedef": true,
 
-  // Enforce line length to 80 characters
-  "maxlen": 80,
+  // Enforce line length to 100 characters
+  "maxlen": 100,
 
   // Require capitalized names for constructor functions.
   "newcap": true,

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 language: node_js
 node_js:
-- '5'
 - '4'
-- '0.12'
-- '0.10'
+- '6'
+- '8'
 services:
 - redis-server
+before_script:
+- npm install -g codecov
+script: npm run testci
 deploy:
   provider: npm
   api_key:

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ make counting simpler.
 
 Read on below or read more on the [documentation site](http://getconversio.github.io/redis-metrics/).
 
+[![Build Status](https://travis-ci.org/getconversio/redis-metrics.svg?branch=master)](https://travis-ci.org/getconversio/redis-metrics)
+[![codecov](https://codecov.io/gh/getconversio/redis-metrics/branch/master/graph/badge.svg)](https://codecov.io/gh/getconversio/redis-metrics)
+
 Install
 -------
 

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -19,7 +19,7 @@
  * @readonly
  * @enum {number}
  */
-var timeGranularities = {
+const timeGranularities = {
   // Long string form
   total: 0,
   none: 0,
@@ -70,11 +70,11 @@ var timeGranularities = {
   6: 6
 };
 
-var momentGranularities = [
+const momentGranularities = [
   '', 'years', 'months', 'days', 'hours', 'minutes', 'seconds'
 ];
 
 module.exports = {
-  timeGranularities: timeGranularities,
-  momentGranularities: momentGranularities
+  timeGranularities,
+  momentGranularities
 };

--- a/lib/counter.js
+++ b/lib/counter.js
@@ -1,18 +1,17 @@
 'use strict';
 
-var _ = require('lodash'),
-    Q = require('q'),
-    moment = require('moment'),
-    timeGranularities = require('./constants').timeGranularities,
-    utils = require('./utils'),
-    lua = require('./lua');
+const _ = require('lodash'),
+  moment = require('moment'),
+  timeGranularities = require('./constants').timeGranularities,
+  utils = require('./utils'),
+  lua = require('./lua');
 
 // The default expiration times aim at having less than 800 counters for a
 // given counter key (event) since the counter keys are stored with a specific
 // timestamp. For example, second-based counters expire after 10 minutes which
 // means that there will be 600 counter keys in the worst-case for a single
 // event.
-var defaultExpiration = {
+const defaultExpiration = {
   total: -1,
   year: -1,
   month:  10 * 365 * 24 * 60 * 60, // 10 years = 120 counters worst-case
@@ -25,21 +24,21 @@ var defaultExpiration = {
 
 // Translate the "nice looking expiration times above to "real" keys that
 // correspond to time granularities.
-_.keys(defaultExpiration).forEach(function(key) {
-  var newKey = timeGranularities[key];
-  var value = defaultExpiration[key];
+_.keys(defaultExpiration).forEach(key => {
+  const newKey = timeGranularities[key];
+  const value = defaultExpiration[key];
   delete defaultExpiration[key];
   defaultExpiration[newKey] = value;
 });
 
-var defaults = {
+const defaults = {
   namespace: 'c', // Short for counter.
   timeGranularity: timeGranularities.none,
   expireKeys: true,
   expiration: defaultExpiration
 };
 
-var momentFormat = 'YYYYMMDDHHmmss';
+const momentFormat = 'YYYYMMDDHHmmss';
 
 /**
  * Convert the given granularity level into the internal representation (a
@@ -47,7 +46,7 @@ var momentFormat = 'YYYYMMDDHHmmss';
  * @returns {module:constants~timeGranularities}
  * @private
  */
-var parseTimeGranularity = function(timeGranularity) {
+const parseTimeGranularity = timeGranularity => {
   timeGranularity = timeGranularities[timeGranularity];
   if (timeGranularity) return timeGranularity;
   else return timeGranularities.none;
@@ -60,21 +59,58 @@ var parseTimeGranularity = function(timeGranularity) {
  * @returns {function}
  * @private
  */
-var createRangeParser = function(keyRange) {
-  return function(results) {
-    return _.zipObject(keyRange, utils.parseIntArray(results));
-  };
-};
+const createRangeParser = keyRange =>
+  results => _.zipObject(keyRange, utils.parseIntArray(results));
 
 /**
  * Creates a function that parses a list of Redis results and returns the total.
  * @returns {function}
  * @private
  */
-var createRangeTotalParser = function() {
-  return function(results) {
-    return _.sum(utils.parseIntArray(results));
-  };
+const createRangeTotalParser = () =>
+  results => _.sum(utils.parseIntArray(results));
+
+const incrSingle = (client, key, amount, eventObj, ttl, cb) => {
+  if (eventObj) {
+    key += ':z';
+
+    if (ttl > 0) {
+      if (cb) client.eval(lua.zincrbyExpire, 1, key, amount, eventObj, ttl, cb);
+      else client.eval(lua.zincrbyExpire, 1, key, amount, eventObj, ttl);
+    } else {
+      if (cb) client.zincrby(key, amount, eventObj, cb);
+      else client.zincrby(key, amount, eventObj);
+    }
+
+  } else { // No event object
+
+    if (ttl > 0) {
+      if (cb) client.eval(lua.incrbyExpire, 1, key, amount, ttl, cb);
+      else client.eval(lua.incrbyExpire, 1, key, amount, ttl);
+    } else {
+      if (cb) client.incrby(key, amount, cb);
+      else client.incrby(key, amount);
+    }
+  }
+};
+
+/**
+ * Parse a rank result from redis
+ * @param  {array} rank In this format: [ 'foo', '39', 'bar', '13' ]
+ * @return {object} In this format: [ { foo: 39 }, { bar: 13 } ]
+ */
+const rankParser = rank => {
+  // groups the array for each second row
+  rank = _.groupBy(rank, (row, index) => Math.floor(index / 2));
+
+  // transform the object into an array
+  // and the values to integer
+  return _.toArray(rank)
+    .map(row => {
+      const _row = {};
+      _row[row[0]] = parseInt(row[1], 10);
+      return _row;
+    });
 };
 
 /**
@@ -99,402 +135,354 @@ var createRangeTotalParser = function() {
  *   options are specified in {@link RedisMetrics#counter}.
  * @class
  */
-function TimestampedCounter(metrics, key, options) {
-  this.options = options || {};
-  _.defaults(this.options, _.cloneDeep(defaults));
+class TimestampedCounter {
+  constructor(metrics, key, options) {
+    this.options = options || {};
+    _.defaults(this.options, _.cloneDeep(defaults));
 
-  this.metrics = metrics;
-  this.key = this.options.namespace + ':' + key;
+    this.metrics = metrics;
+    this.key = this.options.namespace + ':' + key;
 
-  // Translate the expiration keys of the options.
-  var _this = this;
-  _.keys(this.options.expiration).forEach(function(key) {
-    var newKey = timeGranularities[key];
-    var value = _this.options.expiration[key];
-    delete _this.options.expiration[key];
-    _this.options.expiration[newKey] = value;
-  });
+    // Translate the expiration keys of the options.
+    _.keys(this.options.expiration).forEach(key => {
+      const newKey = timeGranularities[key];
+      const value = this.options.expiration[key];
+      delete this.options.expiration[key];
+      this.options.expiration[newKey] = value;
+    });
 
-  this.options.timeGranularity =
-    parseTimeGranularity(this.options.timeGranularity);
-}
+    this.options.timeGranularity = parseTimeGranularity(this.options.timeGranularity);
+  }
 
-/**
- * Return a list of Redis keys that are associated with this counter at the
- * current point in time and will be written to Redis.
- * @returns {Array}
- */
-TimestampedCounter.prototype.getKeys = function() {
-  // Always add the key itself.
-  var keys = [this.key];
+  /**
+   * Return a list of Redis keys that are associated with this counter at the
+   * current point in time and will be written to Redis.
+   * @returns {Array}
+   */
+  getKeys() {
+    // Always add the key itself.
+    const keys = [this.key];
 
-  // If no time granularity is chosen, the timestamped keys will not be used so
-  // just return the default key.
-  if (this.options.timeGranularity === timeGranularities.none) {
+    // If no time granularity is chosen, the timestamped keys will not be used so
+    // just return the default key.
+    if (this.options.timeGranularity === timeGranularities.none) {
+      return keys;
+    }
+
+    const now = moment.utc().format(momentFormat);
+    for (let i = 1; i <= this.options.timeGranularity; i++) {
+      keys.push(this.key + ':' + now.slice(0, i * 2 + 2));
+    }
     return keys;
   }
 
-  var now = moment.utc().format(momentFormat);
-  for (var i = 1; i <= this.options.timeGranularity; i++) {
-    keys.push(this.key + ':' + now.slice(0, i * 2 + 2));
-  }
-  return keys;
-};
+  /**
+   * Finds the configured time to live for the given key.
+   * @param {string} key - The full key (including timestamp) for the key to
+   *   determine the ttl for.
+   * @returns {number} Number of seconds that the key should live.
+   */
+  getKeyTTL(key) {
+    if (!this.options.expireKeys) return -1;
 
-/**
- * Finds the configured time to live for the given key.
- * @param {string} key - The full key (including timestamp) for the key to
- *   determine the ttl for.
- * @returns {number} Number of seconds that the key should live.
- */
-TimestampedCounter.prototype.getKeyTTL = function(key) {
-  if (!this.options.expireKeys) return -1;
-
-  var timePart = key.replace(this.key, '').split(':')[1] || '';
-  var timeGranularity = timeGranularities.none;
-  switch (timePart.length) {
-    case 4:
-      timeGranularity = timeGranularities.year;
-      break;
-    case 6:
-      timeGranularity = timeGranularities.month;
-      break;
-    case 8:
-      timeGranularity = timeGranularities.day;
-      break;
-    case 10:
-      timeGranularity = timeGranularities.hour;
-      break;
-    case 12:
-      timeGranularity = timeGranularities.minute;
-      break;
-    case 14:
-      timeGranularity = timeGranularities.second;
-      break;
-  }
-  var ttl = this.options.expiration[timeGranularity];
-  if (typeof ttl === 'undefined') ttl = defaultExpiration[timeGranularity];
-  return ttl;
-};
-
-/**
- * Increments this counter with 1.
- *
- * For some use cases, it makes sense to pass in an event object to get more
- * precise statistics for a specific event. For example, when counting page
- * views on a page, it makes sense to increment a counter per specific page.
- * For this use case, the eventObj parameter is a good fit.
- *
- * @param {Object|string} [eventObj] - Extra event information used to
- *   determine what counter to increment.
- * @param {function} [callback] - Optional callback.
- * @returns {Promise} A promise that resolves to the results from Redis. Can
- *   be used instead of the callback function.
- * @since 0.1.0
- */
-TimestampedCounter.prototype.incr = function(eventObj, callback) {
-  return this.incrby(1, eventObj, callback);
-};
-
-/**
- * Increments this counter with the given amount.
- *
- * @param {number} amount - The amount to increment with.
- * @param {Object|string} [eventObj] - Extra event information used to
- *   determine what counter to increment. See {@link TimestampedCounter#incr}.
- * @param {function} [callback] - Optional callback.
- * @returns {Promise} A promise that resolves to the results from Redis. Can
- *   be used instead of the callback function.
- * @see {@link TimestampedCounter#incr}
- * @since 0.2.0
- */
-TimestampedCounter.prototype.incrby = function(amount, eventObj, callback) {
-  // The event object is optional so it might be a callback.
-  if (_.isFunction(eventObj)) {
-    callback = eventObj;
-    eventObj = null;
-  }
-  if (eventObj) eventObj = String(eventObj);
-  var deferred = Q.defer();
-  var cb = utils.createRedisCallback(deferred, callback);
-  this._incrby(amount, eventObj, cb);
-  return deferred.promise;
-};
-
-var incrSingle = function(client, key, amount, eventObj, ttl, cb) {
-  if (eventObj) {
-    key += ':z';
-
-    if (ttl > 0) {
-      if (cb) client.eval(lua.zincrbyExpire, 1, key, amount, eventObj, ttl, cb);
-      else client.eval(lua.zincrbyExpire, 1, key, amount, eventObj, ttl);
-    } else {
-      if (cb) client.zincrby(key, amount, eventObj, cb);
-      else client.zincrby(key, amount, eventObj);
+    const timePart = key.replace(this.key, '').split(':')[1] || '';
+    let timeGranularity = timeGranularities.none;
+    switch (timePart.length) {
+      case 4:
+        timeGranularity = timeGranularities.year;
+        break;
+      case 6:
+        timeGranularity = timeGranularities.month;
+        break;
+      case 8:
+        timeGranularity = timeGranularities.day;
+        break;
+      case 10:
+        timeGranularity = timeGranularities.hour;
+        break;
+      case 12:
+        timeGranularity = timeGranularities.minute;
+        break;
+      case 14:
+        timeGranularity = timeGranularities.second;
+        break;
     }
+    let ttl = this.options.expiration[timeGranularity];
+    if (typeof ttl === 'undefined') ttl = defaultExpiration[timeGranularity];
+    return ttl;
+  }
 
-  } else { // No event object
+  /**
+   * Increments this counter with 1.
+   *
+   * For some use cases, it makes sense to pass in an event object to get more
+   * precise statistics for a specific event. For example, when counting page
+   * views on a page, it makes sense to increment a counter per specific page.
+   * For this use case, the eventObj parameter is a good fit.
+   *
+   * @param {Object|string} [eventObj] - Extra event information used to
+   *   determine what counter to increment.
+   * @param {function} [callback] - Optional callback.
+   * @returns {Promise} A promise that resolves to the results from Redis. Can
+   *   be used instead of the callback function.
+   * @since 0.1.0
+   */
+  incr(eventObj, callback) {
+    return this.incrby(1, eventObj, callback);
+  }
 
-    if (ttl > 0) {
-      if (cb) client.eval(lua.incrbyExpire, 1, key, amount, ttl, cb);
-      else client.eval(lua.incrbyExpire, 1, key, amount, ttl);
+  /**
+   * Increments this counter with the given amount.
+   *
+   * @param {number} amount - The amount to increment with.
+   * @param {Object|string} [eventObj] - Extra event information used to
+   *   determine what counter to increment. See {@link TimestampedCounter#incr}.
+   * @param {function} [callback] - Optional callback.
+   * @returns {Promise} A promise that resolves to the results from Redis. Can
+   *   be used instead of the callback function.
+   * @see {@link TimestampedCounter#incr}
+   * @since 0.2.0
+   */
+  incrby(amount, eventObj, callback) {
+    // The event object is optional so it might be a callback.
+    if (_.isFunction(eventObj)) {
+      callback = eventObj;
+      eventObj = null;
+    }
+    if (eventObj) eventObj = String(eventObj);
+    const deferred = utils.defer();
+    const cb = utils.createRedisCallback(deferred, callback);
+    this._incrby(amount, eventObj, cb);
+    return deferred.promise;
+  }
+
+  _incrby(amount, eventObj, cb) {
+    const keys = this.getKeys();
+    // Optimize for the case where there is only a single key to increment.
+    if (keys.length === 1) {
+      incrSingle(this.metrics.client, keys[0], amount, eventObj, this.getKeyTTL(keys[0]), cb);
     } else {
-      if (cb) client.incrby(key, amount, cb);
-      else client.incrby(key, amount);
+      const multi = this.metrics.client.multi();
+      keys.forEach(key => {
+        incrSingle(multi, key, amount, eventObj, this.getKeyTTL(key));
+      });
+      multi.exec(cb);
     }
   }
-};
 
-TimestampedCounter.prototype._incrby = function(amount, eventObj, cb) {
-  var keys = this.getKeys();
-  // Optimize for the case where there is only a single key to increment.
-  if (keys.length === 1) {
-    var ttl = this.getKeyTTL(keys[0]);
-    incrSingle(this.metrics.client, keys[0], amount, eventObj, ttl, cb);
-  } else {
-    var multi = this.metrics.client.multi();
-    var _this = this;
-    keys.forEach(function(key) {
-      var ttl = _this.getKeyTTL(key);
-      incrSingle(multi, key, amount, eventObj, ttl);
-    });
-    multi.exec(cb);
+  /**
+   * Returns the current count for this counter.
+   *
+   * If a specific time granularity is given, the value returned is the current
+   * value at the given granularity level. Effectively, this provides a single
+   * answer to questions such as "what is the count for the current day".
+   *
+   * **Notice**: Counts cannot be returned for a given time granularity if it was
+   * not incremented at this granularity level in the first place.
+   *
+   * @example
+   * myCounter.count((err, result) => {
+   *   console.log(result); // Outputs the global count
+   * });
+   * @example
+   * myCounter.count('year', (err, result) => {
+   *   console.log(result); // Outputs the count for the current year
+   * });
+   * @example
+   * myCounter.count('year', '/foo.html', (err, result) => {
+   *   // Outputs the count for the current year for the event object '/foo.html'
+   *   console.log(result);
+   * });
+   *
+   * @param {module:constants~timeGranularities} [timeGranularity='total'] - The
+   *   granularity level to report the count for.
+   * @param {string|object} [eventObj] - The event object. See
+   *   {@link TimestampedCounter#incr} for more info on event objects.
+   * @param {function} [callback] - Optional callback.
+   * @returns {Promise} A promise that resolves to the result from Redis. Can
+   *   be used instead of the callback function.
+   * @since 0.1.0
+   */
+  count(timeGranularity, eventObj, callback) {
+    const args = Array.prototype.slice.call(arguments);
+
+    // Last argument is callback;
+    callback = typeof args[args.length - 1] === 'function' ? args.pop() : null;
+
+    // Event object requires that the time granularity is specified, otherwise we
+    // can't reliably distinguish between them because both the eventObj and time
+    // granularity can be strings. I miss Python.
+    eventObj = args.length > 1 ? args.pop() : null;
+
+    // Still any arguments left? That's a time granularity.
+    timeGranularity = args.length > 0 ? args.pop() : 'none';
+    timeGranularity = parseTimeGranularity(timeGranularity);
+
+    const deferred = utils.defer();
+    const cb = utils.createRedisCallback(deferred, callback, utils.parseInt);
+    this._count(timeGranularity, eventObj, cb);
+    return deferred.promise;
   }
-};
 
-/**
- * Returns the current count for this counter.
- *
- * If a specific time granularity is given, the value returned is the current
- * value at the given granularity level. Effectively, this provides a single
- * answer to questions such as "what is the count for the current day".
- *
- * **Notice**: Counts cannot be returned for a given time granularity if it was
- * not incremented at this granularity level in the first place.
- *
- * @example
- * myCounter.count(function(err, result) {
- *   console.log(result); // Outputs the global count
- * });
- * @example
- * myCounter.count('year', function(err, result) {
- *   console.log(result); // Outputs the count for the current year
- * });
- * @example
- * myCounter.count('year', '/foo.html', function(err, result) {
- *   // Outputs the count for the current year for the event object '/foo.html'
- *   console.log(result);
- * });
- *
- * @param {module:constants~timeGranularities} [timeGranularity='total'] - The
- *   granularity level to report the count for.
- * @param {string|object} [eventObj] - The event object. See
- *   {@link TimestampedCounter#incr} for more info on event objects.
- * @param {function} [callback] - Optional callback.
- * @returns {Promise} A promise that resolves to the result from Redis. Can
- *   be used instead of the callback function.
- * @since 0.1.0
- */
-TimestampedCounter.prototype.count = function(
-    timeGranularity, eventObj, callback) {
-  var args = Array.prototype.slice.call(arguments);
-
-  // Last argument is callback;
-  callback = typeof args[args.length - 1] === 'function' ? args.pop() : null;
-
-  // Event object requires that the time granularity is specified, otherwise we
-  // can't reliably distinguish between them because both the eventObj and time
-  // granularity can be strings. I miss Python.
-  eventObj = args.length > 1 ? args.pop() : null;
-
-  // Still any arguments left? That's a time granularity.
-  timeGranularity = args.length > 0 ? args.pop() : 'none';
-  timeGranularity = parseTimeGranularity(timeGranularity);
-
-  var deferred = Q.defer();
-  var cb = utils.createRedisCallback(deferred, callback, utils.parseInt);
-  this._count(timeGranularity, eventObj, cb);
-  return deferred.promise;
-};
-
-TimestampedCounter.prototype._count = function(timeGranularity, eventObj, cb) {
-  var theKey = this.getKeys()[timeGranularity];
-  if (eventObj) {
-    this.metrics.client.zscore(theKey + ':z', eventObj, cb);
-  } else {
-    this.metrics.client.get(theKey, cb);
+  _count(timeGranularity, eventObj, cb) {
+    const theKey = this.getKeys()[timeGranularity];
+    if (eventObj) {
+      this.metrics.client.zscore(theKey + ':z', eventObj, cb);
+    } else {
+      this.metrics.client.get(theKey, cb);
+    }
   }
-};
 
-/**
- * Returns an object mapping timestamps to counts in the given time range at a
- * specific time granularity level.
- *
- * Notice: This function does not make sense for the "none" time granularity.
- *
- * @param {module:constants~timeGranularities} timeGranularity - The
- *   granularity level to report the count for.
- * @param {Date|Object|string|number} startDate - Start date for the range
- *   (inclusive). Accepts the same argument as the constructor of a
- *   {@link http://momentjs.com/|moment} date.
- * @param {Date|Object|string|number} [endDate=new Date()] - End date for the
- *   range (inclusive). Accepts the same arguments as the constructor of a
- *   {@link http://momentjs.com/|moment} date.
- * @param {string|object} [eventObj] - The event object. See
- *   {@link TimestampedCounter#incr} for more info on event objects.
- * @param {function} [callback] - Optional callback.
- * @returns {Promise} A promise that resolves to the result from Redis. Can
- *   be used instead of the callback function.
- * @since 0.1.0
- */
-TimestampedCounter.prototype.countRange = function(
-    timeGranularity, startDate, endDate, eventObj, callback) {
-  timeGranularity = parseTimeGranularity(timeGranularity);
-  if (_.isFunction(eventObj)) {
-    callback = eventObj;
-    eventObj = null;
-  } else if (_.isFunction(endDate)) {
-    callback = endDate;
-    endDate = moment.utc();
-  } else {
-    endDate = endDate || moment.utc();
-  }
-  if (eventObj) eventObj = String(eventObj);
+  /**
+   * Returns an object mapping timestamps to counts in the given time range at a
+   * specific time granularity level.
+   *
+   * Notice: This function does not make sense for the "none" time granularity.
+   *
+   * @param {module:constants~timeGranularities} timeGranularity - The
+   *   granularity level to report the count for.
+   * @param {Date|Object|string|number} startDate - Start date for the range
+   *   (inclusive). Accepts the same argument as the constructor of a
+   *   {@link http://momentjs.com/|moment} date.
+   * @param {Date|Object|string|number} [endDate=new Date()] - End date for the
+   *   range (inclusive). Accepts the same arguments as the constructor of a
+   *   {@link http://momentjs.com/|moment} date.
+   * @param {string|object} [eventObj] - The event object. See
+   *   {@link TimestampedCounter#incr} for more info on event objects.
+   * @param {function} [callback] - Optional callback.
+   * @returns {Promise} A promise that resolves to the result from Redis. Can
+   *   be used instead of the callback function.
+   * @since 0.1.0
+   */
+  countRange(timeGranularity, startDate, endDate, eventObj, callback) {
+    timeGranularity = parseTimeGranularity(timeGranularity);
+    if (_.isFunction(eventObj)) {
+      callback = eventObj;
+      eventObj = null;
+    } else if (_.isFunction(endDate)) {
+      callback = endDate;
+      endDate = moment.utc();
+    } else {
+      endDate = endDate || moment.utc();
+    }
+    if (eventObj) eventObj = String(eventObj);
 
-  // Save the report time granularity because it might change.
-  var reportTimeGranularity = timeGranularity;
+    // Save the report time granularity because it might change.
+    const reportTimeGranularity = timeGranularity;
 
-  // If the range granularity is total, fall back to the granularity specified
-  // at the counter level and then add the numbers together when parsing the
-  // result.
-  if (timeGranularity === timeGranularities.total) {
-    timeGranularity = this.options.timeGranularity;
-
-    // If the rangeGranularity is still total, it does not make sense to report
-    // a range for the counter and we throw an error.
+    // If the range granularity is total, fall back to the granularity specified
+    // at the counter level and then add the numbers together when parsing the
+    // result.
     if (timeGranularity === timeGranularities.total) {
-      throw new Error('total granularity not supported for this counter');
+      timeGranularity = this.options.timeGranularity;
+
+      // If the rangeGranularity is still total, it does not make sense to report
+      // a range for the counter and we throw an error.
+      if (timeGranularity === timeGranularities.total) {
+        throw new Error('total granularity not supported for this counter');
+      }
+    }
+
+    const momentRange = utils.momentRange(startDate, endDate, timeGranularity);
+    const keyRange = [];
+    const momentKeyRange = [];
+
+    // Create the range of keys to fetch from Redis as well as the keys to use in
+    // the returned data object.
+    momentRange.forEach(m => {
+      // Redis key range
+      const mKeyFormat = m.format(momentFormat).slice(0, timeGranularity * 2 + 2);
+      keyRange.push(`${this.key}:${mKeyFormat}`);
+
+      // Timestamp range. Use ISO format for easy parsing back to a timestamp.
+      momentKeyRange.push(m.format());
+    });
+
+    const deferred = utils.defer();
+    const parser = reportTimeGranularity === timeGranularities.total ?
+      createRangeTotalParser() : createRangeParser(momentKeyRange);
+    const cb = utils.createRedisCallback(deferred, callback, parser);
+
+    this._countRange(keyRange, eventObj, cb);
+
+    return deferred.promise;
+  }
+
+  _countRange(keys, eventObj, cb) {
+    if (eventObj) {
+      const multi = this.metrics.client.multi();
+      keys.forEach(key => multi.zscore(key + ':z', eventObj));
+      multi.exec(cb);
+    } else {
+      this.metrics.client.mget(keys, cb);
     }
   }
 
-  var momentRange = utils.momentRange(startDate, endDate, timeGranularity);
-  var _this = this;
-  var keyRange = [];
-  var momentKeyRange = [];
+  /**
+   * Returns the current top elements for this counter.
+   *
+   * If a specific time granularity is given, the value returned is the current
+   * value at the given granularity level. Effectively, this provides a single
+   * answer to questions such as "what is the rank for the current day".
+   *
+   * @example
+   * myCounter.top((err, result) => {
+   *   console.log(result); // Outputs the global rank
+   * });
+   * @example
+   * myCounter.top('year', (err, result) => {
+   *   console.log(result); // Outputs the rank for the current year
+   * });
+   *
+   * @param {module:constants~timeGranularities} [timeGranularity='total'] - The
+   *   granularity level to report the rank for.
+   * @param {string} [direction] - Optional sort direction, can be "asc" or "desc"
+   * @param {integer} [startingAt] - Optional starting row, default 0
+   * @param {integer} [limit] - Optional number of results to return, default -1
+   * @param {function} [callback] - Optional callback.
+   * @returns {Promise} A promise that resolves to the result from Redis. Can
+   *   be used instead of the callback function.
+   * @since 0.1.1
+   */
+  top(timeGranularity, direction, startingAt, limit, callback) {
+    const args = Array.prototype.slice.call(arguments);
 
-  // Create the range of keys to fetch from Redis as well as the keys to use in
-  // the returned data object.
-  momentRange.forEach(function(m) {
-    // Redis key range
-    var mKeyFormat = m.format(momentFormat).slice(0, timeGranularity * 2 + 2);
-    keyRange.push(_this.key + ':' + mKeyFormat);
+    // Last argument is callback;
+    callback = typeof args[args.length - 1] === 'function' ? args.pop() : null;
 
-    // Timestamp range. Use ISO format for easy parsing back to a timestamp.
-    momentKeyRange.push(m.format());
-  });
+    limit = args.length > 3 ? args.pop() : -1;
+    startingAt = args.length > 2 ? args.pop() : 0;
+    direction = args.length > 1 ? args.pop() : 'desc';
 
-  var deferred = Q.defer();
-  var parser = reportTimeGranularity === timeGranularities.total ?
-    createRangeTotalParser() : createRangeParser(momentKeyRange);
-  var cb = utils.createRedisCallback(deferred, callback, parser);
+    if (['asc', 'desc'].indexOf(direction) === -1) {
+      throw new Error(
+        'The direction parameter is expected to be one between ' +
+        '"asc" or "desc", got "' + direction + '".'
+      );
+    }
 
-  this._countRange(keyRange, eventObj, cb);
+    timeGranularity = parseTimeGranularity(timeGranularity);
 
-  return deferred.promise;
-};
-
-TimestampedCounter.prototype._countRange = function(keys, eventObj, cb) {
-  if (eventObj) {
-    var multi = this.metrics.client.multi();
-    keys.forEach(function(key) {
-      multi.zscore(key + ':z', eventObj);
-    });
-    multi.exec(cb);
-  } else {
-    this.metrics.client.mget(keys, cb);
-  }
-};
-
-/**
- * Parse a rank result from redis
- * @param  {array} rank In this format: [ 'foo', '39', 'bar', '13' ]
- * @return {object} In this format: [ { foo: 39 }, { bar: 13 } ]
- */
-var rankParser = function(rank) {
-  // groups the array for each second row
-  rank = _.groupBy(rank, function(row, index) {
-    return Math.floor(index / 2);
-  });
-
-  // transform the object into an array
-  // and the values to integer
-  return _.toArray(rank)
-    .map(function(row) {
-      var _row = {};
-      _row[row[0]] = parseInt(row[1], 10);
-
-      return _row;
-    });
-};
-
-/**
- * Returns the current top elements for this counter.
- *
- * If a specific time granularity is given, the value returned is the current
- * value at the given granularity level. Effectively, this provides a single
- * answer to questions such as "what is the rank for the current day".
- *
- * @example
- * myCounter.top(function(err, result) {
- *   console.log(result); // Outputs the global rank
- * });
- * @example
- * myCounter.top('year', function(err, result) {
- *   console.log(result); // Outputs the rank for the current year
- * });
- *
- * @param {module:constants~timeGranularities} [timeGranularity='total'] - The
- *   granularity level to report the rank for.
- * @param {string} [direction] - Optional sort direction, can be "asc" or "desc"
- * @param {integer} [startingAt] - Optional starting row, default 0
- * @param {integer} [limit] - Optional number of results to return, default -1
- * @param {function} [callback] - Optional callback.
- * @returns {Promise} A promise that resolves to the result from Redis. Can
- *   be used instead of the callback function.
- * @since 0.1.1
- */
-TimestampedCounter.prototype.top = function(
-  timeGranularity, direction, startingAt, limit, callback) {
-  var args = Array.prototype.slice.call(arguments);
-
-  // Last argument is callback;
-  callback = typeof args[args.length - 1] === 'function' ? args.pop() : null;
-
-  limit = args.length > 3 ? args.pop() : -1;
-  startingAt = args.length > 2 ? args.pop() : 0;
-  direction = args.length > 1 ? args.pop() : 'desc';
-
-  if (['asc', 'desc'].indexOf(direction) === -1) {
-    throw new Error(
-      'The direction parameter is expected to be one between ' +
-      '"asc" or "desc", got "' + direction + '".'
-    );
+    const deferred = utils.defer();
+    const cb = utils.createRedisCallback(deferred, callback, rankParser);
+    this._top(timeGranularity, direction, startingAt, limit, cb);
+    return deferred.promise;
   }
 
-  timeGranularity = parseTimeGranularity(timeGranularity);
+  _top(timeGranularity, direction, startingAt, limit, cb) {
+    const theKey = this.getKeys()[timeGranularity];
 
-  var deferred = Q.defer();
-  var cb = utils.createRedisCallback(deferred, callback, rankParser);
-  this._top(timeGranularity, direction, startingAt, limit, cb);
-  return deferred.promise;
-};
+    if (direction === 'asc') {
+      return this.metrics.client.zrange(
+        theKey + ':z',
+        startingAt,
+        limit,
+        'WITHSCORES',
+        cb
+      );
+    }
 
-TimestampedCounter.prototype._top = function(
-  timeGranularity, direction, startingAt, limit, cb) {
-  var theKey = this.getKeys()[timeGranularity];
-
-  if (direction === 'asc') {
-    return this.metrics.client.zrange(
+    this.metrics.client.zrevrange(
       theKey + ':z',
       startingAt,
       limit,
@@ -502,14 +490,6 @@ TimestampedCounter.prototype._top = function(
       cb
     );
   }
-
-  this.metrics.client.zrevrange(
-    theKey + ':z',
-    startingAt,
-    limit,
-    'WITHSCORES',
-    cb
-  );
-};
+}
 
 module.exports = TimestampedCounter;

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var redis = require('redis'),
-    _ = require('lodash'),
-    TimestampedCounter = require('./counter');
+const redis = require('redis'),
+  _ = require('lodash'),
+  TimestampedCounter = require('./counter');
 
 /**
  * A simple metrics utility for Redis. Creates a connection to Redis using the
@@ -22,57 +22,56 @@ var redis = require('redis'),
  * @param {Object} [config.counterOptions] - Default counter options to use if
  * none are provided when creating a counter. See {@link RedisMetrics#counter}
  * @example
- * var metrics = new RedisMetrics();
+ * const metrics = new RedisMetrics();
  * metrics.client.on('error', console.error);
  * metrics.counter('coolCounter').incr(1);
  * @class
  */
-function RedisMetrics(config) {
-  if (!(this instanceof RedisMetrics))
-    return new RedisMetrics(config);
+class RedisMetrics {
+  constructor(config) {
+    this.config = config = config || {};
 
-  this.config = config = config || {};
+    if (this.config.client) {
+      this.client = this.config.client;
+    } else if (config.host && config.port) {
+      const redisOptions = config.redisOptions || {};
+      this.client = redis.createClient(config.port, config.host, redisOptions);
+    } else if (config.redisOptions) {
+      this.client = redis.createClient(config.redisOptions);
+    } else {
+      /**
+       * The client connection
+       * @member {Object}
+       * **/
+      this.client = redis.createClient();
+    }
+  }
 
-  if (this.config.client) {
-    this.client = this.config.client;
-  } else if (config.host && config.port) {
-    var redisOptions = config.redisOptions || {};
-    this.client = redis.createClient(config.port, config.host, redisOptions);
-  } else if (config.redisOptions) {
-    this.client = redis.createClient(config.redisOptions);
-  } else {
-    /**
-     * The client connection
-     * @member {Object}
-     * **/
-    this.client = redis.createClient();
+  /**
+   * Returns a timestamped counter for the given event.
+   *
+   * If the counter is initialized without options, it works like a normal event
+   * counter that tracks a total count for the given event key. If a time
+   * granularity option is specified, the counter will be able to report
+   * aggregated counters based on time intervals down to the level of granularity
+   * that is chosen.
+   *
+   * @param {string} eventName - The event that we want to count for.
+   * @param {Object} [options] - The options to use for the counter
+   * @param {number} [options.timeGranularity='none'] - Makes the counter use
+   *   timestamps which means that it can be used to measure event metrics based
+   *   on time intervals. The default is to not use time granularities.
+   * @param {boolean} [options.expireKeys=true] - Automatically expire keys.
+   *   Useful for high time granularity levels to preserve memory.
+   * @returns {TimestampedCounter}
+   * @since 0.1.0
+   */
+  counter(eventName, options) {
+    if (typeof options === 'undefined') {
+      options = _.cloneDeep(this.config.counterOptions);
+    }
+    return new TimestampedCounter(this, eventName, options);
   }
 }
-
-/**
- * Returns a timestamped counter for the given event.
- *
- * If the counter is initialized without options, it works like a normal event
- * counter that tracks a total count for the given event key. If a time
- * granularity option is specified, the counter will be able to report
- * aggregated counters based on time intervals down to the level of granularity
- * that is chosen.
- *
- * @param {string} eventName - The event that we want to count for.
- * @param {Object} [options] - The options to use for the counter
- * @param {number} [options.timeGranularity='none'] - Makes the counter use
- *   timestamps which means that it can be used to measure event metrics based
- *   on time intervals. The default is to not use time granularities.
- * @param {boolean} [options.expireKeys=true] - Automatically expire keys.
- *   Useful for high time granularity levels to preserve memory.
- * @returns {TimestampedCounter}
- * @since 0.1.0
- */
-RedisMetrics.prototype.counter = function(eventName, options) {
-  if (typeof options === 'undefined') {
-    options = _.cloneDeep(this.config.counterOptions);
-  }
-  return new TimestampedCounter(this, eventName, options);
-};
 
 module.exports = RedisMetrics;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -5,29 +5,27 @@
  * @private
  */
 
-var _ = require('lodash'),
-    moment = require('moment'),
-    constants = require('./constants');
+const _ = require('lodash'),
+  moment = require('moment'),
+  constants = require('./constants');
 
 /**
  * Creates a general callback for a redis client function that both resolves
  * the given promise as well as executing the callback function.
- * @param {Promise} deferred - A Q deferred.
+ * @param {Promise} deferred - A deferred promise object.
  * @param {function} [callback] - Optional callback to call.
  * @param {function} [resultParser] - Optional function for parsing the result.
  */
-var createRedisCallback = function(deferred, callback, resultParser) {
-  return function(err, result) {
-    // (Maybe) parse the result.
-    if (typeof resultParser === 'function') result = resultParser(result);
+const createRedisCallback = (deferred, callback, resultParser) => (err, result) => {
+  // (Maybe) parse the result.
+  if (typeof resultParser === 'function') result = resultParser(result);
 
-    // Handle the deferred.
-    if (err) deferred.reject(err);
-    else deferred.resolve(result);
+  // Handle the deferred.
+  if (err) deferred.reject(err);
+  else deferred.resolve(result);
 
-    // (Maybe call the callback)
-    if (typeof callback === 'function') callback(err, result);
-  };
+  // (Maybe call the callback)
+  if (typeof callback === 'function') callback(err, result);
 };
 
 /**
@@ -37,7 +35,7 @@ var createRedisCallback = function(deferred, callback, resultParser) {
  * @returns {number} An integer. If the provided value cannot be parsed, the
  * function returns 0.
  */
-var parseIntSingle = function(i) {
+const parseIntSingle = i => {
   i = parseInt(i, 10);
   return _.isFinite(i) ? i : 0;
 };
@@ -48,13 +46,9 @@ var parseIntSingle = function(i) {
  * @returns {array} An array of integers. If any value in the original array
  * cannot be parsed, the integer value will be 0 for this index.
  */
-var parseIntArray = function(arrayOfInts) {
-  return arrayOfInts.map(function(i) {
-    return parseIntSingle(i);
-  });
-};
+const parseIntArray = arrayOfInts => arrayOfInts.map(i => parseIntSingle(i));
 
-var momentRange = function(startDate, endDate, timeGranularity) {
+const momentRange = (startDate, endDate, timeGranularity) => {
   timeGranularity = constants.timeGranularities[timeGranularity];
   startDate = moment.utc(startDate);
   endDate = moment.utc(endDate);
@@ -84,20 +78,30 @@ var momentRange = function(startDate, endDate, timeGranularity) {
     endDate.month(0);
   }
 
-  var momentGranularity = constants.momentGranularities[timeGranularity];
-  var timestamps = [];
+  const momentGranularity = constants.momentGranularities[timeGranularity];
+  const timestamps = [];
 
   endDate.add(1, 'millisecond');
-  for (var m = startDate; m.isBefore(endDate); m.add(1, momentGranularity)) {
+  for (let m = startDate; m.isBefore(endDate); m.add(1, momentGranularity)) {
     timestamps.push(moment(m));
   }
 
   return timestamps;
 };
 
+const defer = () => {
+  const deferred = {};
+  deferred.promise = new Promise((resolve, reject) => {
+    deferred.resolve = resolve;
+    deferred.reject = reject;
+  });
+  return deferred;
+};
+
 module.exports = {
-  createRedisCallback: createRedisCallback,
-  parseInt: parseIntSingle,
-  parseIntArray: parseIntArray,
-  momentRange: momentRange
+  createRedisCallback,
+  parseIntArray,
+  momentRange,
+  defer,
+  parseInt: parseIntSingle
 };

--- a/package.json
+++ b/package.json
@@ -1,14 +1,16 @@
 {
   "name": "redis-metrics",
-  "version": "0.5.0",
+  "version": "1.0.0",
   "description": "Easy metric tracking and aggregation using Redis",
   "main": "lib/metrics.js",
   "scripts": {
     "exectests": "node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha",
+    "codecov": "node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha --report lcovonly -- -R spec && codecov",
     "jshint": "node_modules/.bin/jshint lib test",
     "jscs": "node_modules/.bin/jscs lib test",
     "lint": "npm run jshint && npm run jscs",
     "test": "npm run exectests && npm run lint",
+    "testci": "npm run lint && npm run codecov",
     "docs": "node_modules/.bin/jsdoc -c jsdoc.json"
   },
   "repository": {
@@ -27,20 +29,19 @@
   "author": "Conversio <dev@conversio.com> (https://conversio.com)",
   "license": "MIT",
   "dependencies": {
-    "jscs": "^2.11.0",
     "lodash": "^3.6.0",
     "moment": "^2.11.1",
-    "q": "^1.2.0",
     "redis": "^2.5.3"
   },
   "devDependencies": {
     "async": "^0.9.0",
-    "chai": "^2.2.0",
+    "chai": "^4.1.1",
     "ioredis": "^2.5.0",
     "istanbul": "^0.3.13",
+    "jscs": "^2.11.0",
     "jsdoc": "^3.4.3",
     "jshint": "^2.7.0",
-    "mocha": "^2.2.4",
+    "mocha": "^3.5.0",
     "sinon": "^1.14.1"
   }
 }

--- a/test/counter.js
+++ b/test/counter.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var chai = require('chai'),
+const chai = require('chai'),
   sinon = require('sinon'),
   moment = require('moment'),
   IORedis = require('ioredis'),
@@ -8,18 +8,18 @@ var chai = require('chai'),
   TimestampedCounter = require('../lib/counter'),
   utils = require('../lib/utils');
 
-var expect = chai.expect;
+const expect = chai.expect;
 
-describe('Counter', function() {
+describe('Counter', () => {
 
-  var metrics;
-  var sandbox;
-  beforeEach(function(done) {
+  let metrics;
+  let sandbox;
+  beforeEach(done => {
     sandbox = sinon.sandbox.create();
-    var host = process.env.REDIS_HOST || 'localhost';
-    var port = process.env.REDIS_PORT || 6379;
+    const host = process.env.REDIS_HOST || 'localhost';
+    const port = process.env.REDIS_PORT || 6379;
     if (process.env.USE_IOREDIS) {
-      var client = new IORedis(port, host);
+      const client = new IORedis(port, host);
       metrics = new RedisMetrics({ client: client });
     } else {
       metrics = new RedisMetrics({
@@ -30,15 +30,15 @@ describe('Counter', function() {
     metrics.client.flushall(done);
   });
 
-  afterEach(function(done) {
+  afterEach(done => {
     sandbox.restore();
     metrics.client.quit(done);
   });
 
-  describe('constructor', function() {
+  describe('constructor', () => {
 
-    it('should set some defaults', function() {
-      var counter = new TimestampedCounter(metrics, 'foo');
+    it('should set some defaults', () => {
+      const counter = new TimestampedCounter(metrics, 'foo');
       expect(counter.metrics).to.equal(metrics);
       expect(counter.key).to.equal('c:foo');
       expect(counter.options.timeGranularity).to.equal(0);
@@ -46,16 +46,16 @@ describe('Counter', function() {
       expect(counter.options.namespace).to.equal('c');
     });
 
-    it('should respect the passed namespace in the key', function() {
-      var counter = new TimestampedCounter(metrics, 'foo', {
+    it('should respect the passed namespace in the key', () => {
+      const counter = new TimestampedCounter(metrics, 'foo', {
         namespace: 'stats'
       });
       expect(counter.key).to.equal('stats:foo');
       expect(counter.options.namespace).to.equal('stats');
     });
 
-    it('should reset an incorrect time granularity to "none"', function() {
-      var counter = new TimestampedCounter(metrics, 'foo', {
+    it('should reset an incorrect time granularity to "none"', () => {
+      let counter = new TimestampedCounter(metrics, 'foo', {
         timeGranularity: -10
       });
       expect(counter.options.timeGranularity).to.equal(0);
@@ -67,22 +67,22 @@ describe('Counter', function() {
     });
   });
 
-  describe('getKeys', function() {
-    it('should return an array of keys', function() {
-      var counter = new TimestampedCounter(metrics, 'foo');
-      var keys = counter.getKeys();
+  describe('getKeys', () => {
+    it('should return an array of keys', () => {
+      const counter = new TimestampedCounter(metrics, 'foo');
+      const keys = counter.getKeys();
       expect(keys).to.be.instanceof(Array);
       expect(keys).to.have.length.above(0);
       expect(keys).to.include('c:foo');
     });
 
-    it('should return keys based on the granularity level', function() {
+    it('should return keys based on the granularity level', () => {
       sandbox.useFakeTimers(new Date('2015-01-02T03:04:05Z').getTime());
 
-      var counter = new TimestampedCounter(metrics, 'foo', {
+      let counter = new TimestampedCounter(metrics, 'foo', {
         timeGranularity: 'none'
       });
-      var keys = counter.getKeys();
+      let keys = counter.getKeys();
       expect(keys).to.be.instanceof(Array);
       expect(keys).to.have.length(1);
       expect(keys).to.include('c:foo');
@@ -155,64 +155,64 @@ describe('Counter', function() {
     });
   });
 
-  describe('getKeyTTL', function() {
-    it('should the default for seconds', function() {
-      var counter = new TimestampedCounter(metrics, 'foo');
-      var key = 'c:foo:20150102030405';
-      var ttl = counter.getKeyTTL(key);
+  describe('getKeyTTL', () => {
+    it('should the default for seconds', () => {
+      const counter = new TimestampedCounter(metrics, 'foo');
+      const key = 'c:foo:20150102030405';
+      const ttl = counter.getKeyTTL(key);
       expect(ttl).to.equal(10 * 60);
     });
 
-    it('should the default for minutes', function() {
-      var counter = new TimestampedCounter(metrics, 'foo');
-      var key = 'c:foo:201501020304';
-      var ttl = counter.getKeyTTL(key);
+    it('should the default for minutes', () => {
+      const counter = new TimestampedCounter(metrics, 'foo');
+      const key = 'c:foo:201501020304';
+      const ttl = counter.getKeyTTL(key);
       expect(ttl).to.equal(12 * 60 * 60);
     });
 
-    it('should the default for hours', function() {
-      var counter = new TimestampedCounter(metrics, 'foo');
-      var key = 'c:foo:2015010203';
-      var ttl = counter.getKeyTTL(key);
+    it('should the default for hours', () => {
+      const counter = new TimestampedCounter(metrics, 'foo');
+      const key = 'c:foo:2015010203';
+      const ttl = counter.getKeyTTL(key);
       expect(ttl).to.equal(31 * 24 * 60 * 60);
     });
 
-    it('should the default for days', function() {
-      var counter = new TimestampedCounter(metrics, 'foo');
-      var key = 'c:foo:20150102';
-      var ttl = counter.getKeyTTL(key);
+    it('should the default for days', () => {
+      const counter = new TimestampedCounter(metrics, 'foo');
+      const key = 'c:foo:20150102';
+      const ttl = counter.getKeyTTL(key);
       expect(ttl).to.equal(2 * 365 * 24 * 60 * 60);
     });
 
-    it('should the default for months', function() {
-      var counter = new TimestampedCounter(metrics, 'foo');
-      var key = 'c:foo:201501';
-      var ttl = counter.getKeyTTL(key);
+    it('should the default for months', () => {
+      const counter = new TimestampedCounter(metrics, 'foo');
+      const key = 'c:foo:201501';
+      const ttl = counter.getKeyTTL(key);
       expect(ttl).to.equal(10 * 365 * 24 * 60 * 60);
     });
 
-    it('should the default for years', function() {
-      var counter = new TimestampedCounter(metrics, 'foo');
-      var key = 'c:foo:2015';
-      var ttl = counter.getKeyTTL(key);
+    it('should the default for years', () => {
+      const counter = new TimestampedCounter(metrics, 'foo');
+      const key = 'c:foo:2015';
+      const ttl = counter.getKeyTTL(key);
       expect(ttl).to.equal(-1);
     });
 
-    it('should the default for none', function() {
-      var counter = new TimestampedCounter(metrics, 'foo');
-      var key = 'c:foo';
-      var ttl = counter.getKeyTTL(key);
+    it('should the default for none', () => {
+      const counter = new TimestampedCounter(metrics, 'foo');
+      const key = 'c:foo';
+      const ttl = counter.getKeyTTL(key);
       expect(ttl).to.equal(-1);
     });
 
-    it('should allow the expiration to be configured', function() {
-      var counter = new TimestampedCounter(metrics, 'foo', {
+    it('should allow the expiration to be configured', () => {
+      let counter = new TimestampedCounter(metrics, 'foo', {
         expiration: {
           total: 1
         }
       });
-      var key = 'c:foo';
-      var ttl = counter.getKeyTTL(key);
+      const key = 'c:foo';
+      let ttl = counter.getKeyTTL(key);
       expect(ttl).to.equal(1);
 
       counter = new TimestampedCounter(metrics, 'foo', {
@@ -243,121 +243,121 @@ describe('Counter', function() {
       expect(ttl).to.equal(4);
     });
 
-    it('should return the default value if conf is missing', function() {
-      var counter = new TimestampedCounter(metrics, 'foo', {
+    it('should return the default value if conf is missing', () => {
+      const counter = new TimestampedCounter(metrics, 'foo', {
         expiration: {
           total: 10
         }
       });
       // Only total is set, yearly is not, use default of -1
-      var key = 'c:foo:2015';
-      var ttl = counter.getKeyTTL(key);
+      const key = 'c:foo:2015';
+      const ttl = counter.getKeyTTL(key);
       expect(ttl).to.equal(-1);
     });
   });
 
-  describe('incr', function() {
-    it('should call redis without a trans when keys dont expire', function() {
-      var multiSpy = sandbox.spy(metrics.client, 'multi');
-      var incrSpy = sandbox.spy(metrics.client, 'incrby');
+  describe('incr', () => {
+    it('should call redis without a trans when keys dont expire', () => {
+      const multiSpy = sandbox.spy(metrics.client, 'multi');
+      const incrSpy = sandbox.spy(metrics.client, 'incrby');
 
-      var counter = new TimestampedCounter(
+      const counter = new TimestampedCounter(
         metrics,
         'foo',
         { expireKeys: false }
       );
-      return counter.incr().then(function() {
+      return counter.incr().then(() => {
         sinon.assert.calledOnce(incrSpy);
         sinon.assert.notCalled(multiSpy);
       });
     });
 
-    it('should call redis without a trans when counters expire', function() {
-      var multiSpy = sandbox.spy(metrics.client, 'multi');
-      var evalSpy = sandbox.spy(metrics.client, 'eval');
+    it('should call redis without a trans when counters expire', () => {
+      const multiSpy = sandbox.spy(metrics.client, 'multi');
+      const evalSpy = sandbox.spy(metrics.client, 'eval');
 
-      var counter = new TimestampedCounter(metrics, 'foo', {
+      const counter = new TimestampedCounter(metrics, 'foo', {
         expireKeys: true,
         expiration: {
           total: 10
         }
       });
-      return counter.incr().then(function() {
+      return counter.incr().then(() => {
         sinon.assert.calledOnce(evalSpy);
         sinon.assert.notCalled(multiSpy);
       });
     });
 
-    it('should call redis when a time granularity is chosen', function() {
-      var multiSpy = sandbox.spy(metrics.client, 'multi');
+    it('should call redis when a time granularity is chosen', () => {
+      const multiSpy = sandbox.spy(metrics.client, 'multi');
 
-      var counter = new TimestampedCounter(metrics, 'foo', {
+      const counter = new TimestampedCounter(metrics, 'foo', {
         timeGranularity: 'year'
       });
 
-      return counter.incr().then(function() {
+      return counter.incr().then(() => {
         sinon.assert.calledOnce(multiSpy);
       });
     });
 
-    it('should call the callback on success', function(done) {
-      var counter = new TimestampedCounter(metrics, 'foo');
-      counter.incr(function(err, result) {
+    it('should call the callback on success', done => {
+      const counter = new TimestampedCounter(metrics, 'foo');
+      counter.incr((err, result) => {
         expect(err).to.equal(null);
         expect(result).to.equal(1);
         done();
       });
     });
 
-    it('should resolve a promise on success', function(done) {
-      var counter = new TimestampedCounter(metrics, 'foo');
-      counter.incr().then(function(result) {
+    it('should resolve a promise on success', done => {
+      const counter = new TimestampedCounter(metrics, 'foo');
+      counter.incr().then(result => {
         expect(result).to.equal(1);
         done();
       })
       .catch(done);
     });
 
-    it('should call the callback on error', function(done) {
+    it('should call the callback on error', done => {
       sandbox.stub(metrics.client, 'incrby')
         .yields(new Error('oh no'), null);
 
-      var counter = new TimestampedCounter(
+      const counter = new TimestampedCounter(
         metrics,
         'foo',
         { expireKeys: false }
       );
-      counter.incr(function(err, result) {
+      counter.incr((err, result) => {
         expect(err).to.not.equal(null);
         expect(result).to.equal(null);
         done();
       });
     });
 
-    it('should reject the promise on error', function(done) {
+    it('should reject the promise on error', done => {
       sandbox.stub(metrics.client, 'incrby')
         .yields(new Error('oh no'), null);
 
-      var counter = new TimestampedCounter(
+      const counter = new TimestampedCounter(
         metrics,
         'foo',
         { expireKeys: false }
       );
-      counter.incr().then(function() {
+      counter.incr().then(() => {
         done(new Error('Should not be here'));
       })
-      .catch(function(err) {
+      .catch(err => {
         expect(err).to.not.equal(null);
         done();
       });
     });
 
-    it('should return a list of results', function(done) {
-      var counter = new TimestampedCounter(metrics, 'foo', {
+    it('should return a list of results', done => {
+      const counter = new TimestampedCounter(metrics, 'foo', {
         timeGranularity: 'year'
       });
 
-      counter.incr().then(function(results) {
+      counter.incr().then(results => {
         expect(results).to.be.instanceof(Array);
         expect(results).to.deep.equal([1, 1]);
         done();
@@ -365,13 +365,13 @@ describe('Counter', function() {
       .catch(done);
     });
 
-    it('should return a list of results for non-expiring keys', function(done) {
-      var counter = new TimestampedCounter(metrics, 'foo', {
+    it('should return a list of results for non-expiring keys', done => {
+      const counter = new TimestampedCounter(metrics, 'foo', {
         timeGranularity: 'year',
         expireKeys: false
       });
 
-      counter.incr().then(function(results) {
+      counter.incr().then(results => {
         expect(results).to.be.instanceof(Array);
         expect(results).to.deep.equal([1, 1]);
         done();
@@ -380,35 +380,35 @@ describe('Counter', function() {
     });
   });
 
-  describe('incr with event object', function() {
+  describe('incr with event object', () => {
 
-    it('should work with an event object when a counter expires', function() {
-      var counter = new TimestampedCounter(metrics, 'foo', {
+    it('should work with an event object when a counter expires', () => {
+      const counter = new TimestampedCounter(metrics, 'foo', {
         expireKeys: true,
         expiration: {
           total: 10
         }
       });
 
-      return counter.incr('bar').then(function(result) {
+      return counter.incr('bar').then(result => {
         expect(parseInt(result)).to.equal(1);
       });
     });
 
-    it('should work with an event object and non-expiring keys', function() {
-      var counter = new TimestampedCounter(
+    it('should work with an event object and non-expiring keys', () => {
+      const counter = new TimestampedCounter(
         metrics,
         'foo',
         { expireKeys: false }
       );
 
-      return counter.incr('bar').then(function(result) {
+      return counter.incr('bar').then(result => {
         expect(parseInt(result)).to.equal(1);
       });
     });
 
-    it('should work with an event, time gran, a counter that exp', function() {
-      var counter = new TimestampedCounter(metrics, 'foo', {
+    it('should work with an event, time gran, a counter that exp', () => {
+      const counter = new TimestampedCounter(metrics, 'foo', {
         timeGranularity: 'year',
         expireKeys: true,
         expiration: {
@@ -416,35 +416,35 @@ describe('Counter', function() {
         }
       });
 
-      return counter.incr('bar').then(function(results) {
+      return counter.incr('bar').then(results => {
         expect(utils.parseIntArray(results)).to.deep.equal([1, 1]);
       });
     });
 
-    it('should work with an event, time gran and non-exp keys', function() {
-      var counter = new TimestampedCounter(metrics, 'foo', {
+    it('should work with an event, time gran and non-exp keys', () => {
+      const counter = new TimestampedCounter(metrics, 'foo', {
         timeGranularity: 'year',
         expireKeys: false
       });
 
-      return counter.incr('bar').then(function(results) {
+      return counter.incr('bar').then(results => {
         expect(utils.parseIntArray(results)).to.deep.equal([1, 1]);
       });
     });
 
   });
 
-  describe('incrby', function() {
-    it('should call redis without a tran when keys do not exp', function(done) {
-      var multiSpy = sandbox.spy(metrics.client, 'multi');
-      var incrSpy = sandbox.spy(metrics.client, 'incrby');
+  describe('incrby', () => {
+    it('should call redis without a tran when keys do not exp', done => {
+      const multiSpy = sandbox.spy(metrics.client, 'multi');
+      const incrSpy = sandbox.spy(metrics.client, 'incrby');
 
-      var counter = new TimestampedCounter(
+      const counter = new TimestampedCounter(
         metrics,
         'foo',
         { expireKeys: false }
       );
-      counter.incrby(2).then(function() {
+      counter.incrby(2).then(() => {
         sinon.assert.calledOnce(incrSpy);
         sinon.assert.notCalled(multiSpy);
         done();
@@ -452,17 +452,17 @@ describe('Counter', function() {
       .catch(done);
     });
 
-    it('should call redis without a trans when counters exp', function(done) {
-      var multiSpy = sandbox.spy(metrics.client, 'multi');
-      var evalSpy = sandbox.spy(metrics.client, 'eval');
+    it('should call redis without a trans when counters exp', done => {
+      const multiSpy = sandbox.spy(metrics.client, 'multi');
+      const evalSpy = sandbox.spy(metrics.client, 'eval');
 
-      var counter = new TimestampedCounter(metrics, 'foo', {
+      const counter = new TimestampedCounter(metrics, 'foo', {
         expireKeys: true,
         expiration: {
           total: 10
         }
       });
-      counter.incrby(2).then(function() {
+      counter.incrby(2).then(() => {
         sinon.assert.calledOnce(evalSpy);
         sinon.assert.notCalled(multiSpy);
         done();
@@ -470,114 +470,114 @@ describe('Counter', function() {
       .catch(done);
     });
 
-    it('should call redis when a time granularity is chosen', function(done) {
-      var multiSpy = sandbox.spy(metrics.client, 'multi');
+    it('should call redis when a time granularity is chosen', done => {
+      const multiSpy = sandbox.spy(metrics.client, 'multi');
 
-      var counter = new TimestampedCounter(metrics, 'foo', {
+      const counter = new TimestampedCounter(metrics, 'foo', {
         timeGranularity: 'year'
       });
 
-      counter.incrby(3).then(function() {
+      counter.incrby(3).then(() => {
         sinon.assert.calledOnce(multiSpy);
         done();
       })
       .catch(done);
     });
 
-    it('should call the callback on success', function(done) {
-      var counter = new TimestampedCounter(metrics, 'foo');
-      counter.incrby(4, function(err, result) {
+    it('should call the callback on success', done => {
+      const counter = new TimestampedCounter(metrics, 'foo');
+      counter.incrby(4, (err, result) => {
         expect(err).to.equal(null);
         expect(result).to.equal(4);
         done();
       });
     });
 
-    it('should resolve a promise on success', function(done) {
-      var counter = new TimestampedCounter(metrics, 'foo');
-      counter.incrby(5).then(function(result) {
+    it('should resolve a promise on success', done => {
+      const counter = new TimestampedCounter(metrics, 'foo');
+      counter.incrby(5).then(result => {
         expect(result).to.equal(5);
         done();
       })
       .catch(done);
     });
 
-    it('should call the callback on error from incrby', function(done) {
+    it('should call the callback on error from incrby', done => {
       sandbox.stub(metrics.client, 'incrby')
         .yields(new Error('oh no'), null);
 
-      var counter = new TimestampedCounter(
+      const counter = new TimestampedCounter(
         metrics,
         'foo',
         { expireKeys: false }
       );
-      counter.incrby(6, function(err, result) {
+      counter.incrby(6, (err, result) => {
         expect(err).to.not.equal(null);
         expect(result).to.equal(null);
         done();
       });
     });
 
-    it('should call the callback on error from eval', function(done) {
+    it('should call the callback on error from eval', done => {
       sandbox.stub(metrics.client, 'eval')
         .yields(new Error('oh no'), null);
 
-      var counter = new TimestampedCounter(metrics, 'foo', {
+      const counter = new TimestampedCounter(metrics, 'foo', {
         expireKeys: true,
         expiration: {
           total: 10
         }
       });
-      counter.incrby(6, function(err, result) {
+      counter.incrby(6, (err, result) => {
         expect(err).to.not.equal(null);
         expect(result).to.equal(null);
         done();
       });
     });
 
-    it('should reject the promise on redis error from incrby', function(done) {
+    it('should reject the promise on redis error from incrby', done => {
       sandbox.stub(metrics.client, 'incrby')
         .yields(new Error('oh no'), null);
 
-      var counter = new TimestampedCounter(
+      const counter = new TimestampedCounter(
         metrics,
         'foo',
         { expireKeys: false }
       );
-      counter.incrby(7).then(function() {
+      counter.incrby(7).then(() => {
         done(new Error('Should not be here'));
       })
-      .catch(function(err) {
+      .catch(err => {
         expect(err).to.not.equal(null);
         done();
       });
     });
 
-    it('should reject the promise on redis error with eval', function(done) {
+    it('should reject the promise on redis error with eval', done => {
       sandbox.stub(metrics.client, 'eval')
         .yields(new Error('oh no'), null);
 
-      var counter = new TimestampedCounter(metrics, 'foo', {
+      const counter = new TimestampedCounter(metrics, 'foo', {
         expireKeys: true,
         expiration: {
           total: 10
         }
       });
-      counter.incrby(7).then(function() {
+      counter.incrby(7).then(() => {
         done(new Error('Should not be here'));
       })
-      .catch(function(err) {
+      .catch(err => {
         expect(err).to.not.equal(null);
         done();
       });
     });
 
-    it('should return a list of results from the operation', function(done) {
-      var counter = new TimestampedCounter(metrics, 'foo', {
+    it('should return a list of results from the operation', done => {
+      const counter = new TimestampedCounter(metrics, 'foo', {
         timeGranularity: 'year'
       });
 
-      counter.incrby(8).then(function(results) {
+      counter.incrby(8).then(results => {
         expect(results).to.be.instanceof(Array);
         expect(results).to.deep.equal([8, 8]);
         done();
@@ -586,24 +586,24 @@ describe('Counter', function() {
     });
   });
 
-  describe('incrby with event object', function() {
+  describe('incrby with event object', () => {
 
-    it('should work with an event object', function(done) {
-      var counter = new TimestampedCounter(metrics, 'foo');
+    it('should work with an event object', done => {
+      const counter = new TimestampedCounter(metrics, 'foo');
 
-      counter.incrby(9, 'bar').then(function(result) {
+      counter.incrby(9, 'bar').then(result => {
         expect(parseInt(result)).to.equal(9);
         done();
       })
       .catch(done);
     });
 
-    it('should work with an event object and time granularity', function(done) {
-      var counter = new TimestampedCounter(metrics, 'foo', {
+    it('should work with an event object and time granularity', done => {
+      const counter = new TimestampedCounter(metrics, 'foo', {
         timeGranularity: 'year'
       });
 
-      counter.incrby(10, 'bar').then(function(results) {
+      counter.incrby(10, 'bar').then(results => {
         expect(utils.parseIntArray(results)).to.deep.equal([10, 10]);
         done();
       })
@@ -612,112 +612,96 @@ describe('Counter', function() {
 
   });
 
-  describe('count', function() {
-    it('should work with callback', function(done) {
-      var mock = sandbox.mock(metrics.client)
+  describe('count', () => {
+    it('should work with callback', done => {
+      const mock = sandbox.mock(metrics.client)
         .expects('get')
         .once()
         .yields(null, '10');
 
-      var counter = new TimestampedCounter(metrics, 'foo');
-      counter.count(function(err, result) {
+      const counter = new TimestampedCounter(metrics, 'foo');
+      counter.count((err, result) => {
         mock.verify();
         expect(result).to.equal(10);
         done(err);
       });
     });
 
-    it('should work with time granularity and callback', function(done) {
-      var mock = sandbox.mock(metrics.client)
+    it('should work with time granularity and callback', done => {
+      const mock = sandbox.mock(metrics.client)
         .expects('get')
         .once()
         .yields(null, '10');
 
-      var counter = new TimestampedCounter(metrics, 'foo');
-      counter.count('none', function(err, result) {
+      const counter = new TimestampedCounter(metrics, 'foo');
+      counter.count('none', (err, result) => {
         mock.verify();
         expect(result).to.equal(10);
         done(err);
       });
     });
 
-    it('should work with time gran, event object and callback', function(done) {
-      var mock = sandbox.mock(metrics.client)
+    it('should work with time gran, event object and callback', done => {
+      const mock = sandbox.mock(metrics.client)
         .expects('zscore')
         .once()
         .yields(null, '10');
 
-      var counter = new TimestampedCounter(metrics, 'foo');
-      counter.count('none', 'bar', function(err, result) {
+      const counter = new TimestampedCounter(metrics, 'foo');
+      counter.count('none', 'bar', (err, result) => {
         mock.verify();
         expect(result).to.equal(10);
         done(err);
       });
     });
 
-    it('should return a single res when no arg are given', function(done) {
-      var counter = new TimestampedCounter(metrics, 'foo');
-      counter.incr()
-        .then(function() {
-          return counter.incr();
-        })
-        .then(function() {
-          return counter.incr();
-        })
-        .then(function() {
-          return counter.count();
-        })
-        .then(function(result) {
+    it('should return a single res when no arg are given', () => {
+      const counter = new TimestampedCounter(metrics, 'foo');
+      return counter.incr()
+        .then(() => counter.incr())
+        .then(() => counter.incr())
+        .then(() => counter.count())
+        .then(result => {
           // Counter has been incremented 3 times.
           expect(result).to.equal(3);
-          done();
-        })
-        .catch(done);
+        });
     });
 
-    it('should return a single result for an event object', function(done) {
-      var counter = new TimestampedCounter(metrics, 'foo');
-      counter.incr('bar')
-        .then(function() {
-          return counter.incr('bar');
-        })
-        .then(function() {
-          return counter.incr('bar');
-        })
-        .then(function() {
-          return counter.count('total', 'bar');
-        })
-        .then(function(result) {
+    it('should return a single result for an event object', () => {
+      const counter = new TimestampedCounter(metrics, 'foo');
+      return counter.incr('bar')
+        .then(() => counter.incr('bar'))
+        .then(() => counter.incr('bar'))
+        .then(() => counter.count('total', 'bar'))
+        .then(result => {
           // Counter has been incremented 3 times.
           expect(result).to.equal(3);
-          done();
-        })
-        .catch(done);
+        });
     });
 
-    it('should return 0 when the key does not exist (cb)', function(done) {
-      var mock = sandbox.mock(metrics.client)
+    it('should return 0 when the key does not exist (cb)', done => {
+      const mock = sandbox.mock(metrics.client)
         .expects('get')
         .once()
         .yields(null, null);
 
-      var counter = new TimestampedCounter(metrics, 'foo');
-      counter.count(function(err, result) {
+      const counter = new TimestampedCounter(metrics, 'foo');
+      counter.count((err, result) => {
         mock.verify();
         expect(result).to.equal(0);
         done(err);
       });
     });
 
-    it('should return 0 when the key does not exist (promise)', function(done) {
-      var mock = sandbox.mock(metrics.client)
+    it('should return 0 when the key does not exist (promise)', done => {
+      const mock = sandbox.mock(metrics.client)
         .expects('get')
         .once()
         .yields(null, null);
 
-      var counter = new TimestampedCounter(metrics, 'foo');
+      const counter = new TimestampedCounter(metrics, 'foo');
       counter.count()
-        .then(function(result) {
+        .then(result => {
           mock.verify();
           expect(result).to.equal(0);
           done();
@@ -725,93 +709,79 @@ describe('Counter', function() {
         .catch(done);
     });
 
-    it('should return a count for a specific time granularity', function(done) {
-      var counter = new TimestampedCounter(metrics, 'foo', {
+    it('should return a count for a specific time granularity', () => {
+      const counter = new TimestampedCounter(metrics, 'foo', {
         timeGranularity: 'year'
       });
 
       // Increment in 2014 and 2015
       // Total should be 2 but year should be 1.
 
-      var clock = sandbox.useFakeTimers(new Date('2014-02-01').getTime());
-      counter.incr()
-        .then(function() {
+      const clock = sandbox.useFakeTimers(new Date('2014-02-01').getTime());
+      return counter.incr()
+        .then(() => {
           clock.tick(1000 * 60 * 60 * 24 * 365);
           return counter.incr();
         })
-        .then(function() {
-          return counter.count('none'); // same as counter.count();
-        })
-        .then(function(result) {
+        .then(() => counter.count('none')) // same as counter.count();
+        .then(result => {
           expect(result).to.equal(2);
           return counter.count('year');
         })
-        .then(function(result) {
-          expect(result).to.equal(1);
-          done();
-        })
-        .catch(done);
+        .then(result => expect(result).to.equal(1));
     });
 
-    it('should return a count for a specific time gran and event', function() {
-      var counter = new TimestampedCounter(metrics, 'foo', {
+    it('should return a count for a specific time gran and event', () => {
+      const counter = new TimestampedCounter(metrics, 'foo', {
         timeGranularity: 'year'
       });
 
       // Increment in 2014 and 2015
       // Total should be 2 but year should be 1.
 
-      var clock = sandbox.useFakeTimers(new Date('2014-02-01').getTime());
+      const clock = sandbox.useFakeTimers(new Date('2014-02-01').getTime());
       return counter.incr('bar')
-        .then(function() {
+        .then(() => {
           clock.tick(1000 * 60 * 60 * 24 * 365);
           return counter.incr('bar');
         })
-        .then(function() {
-          return counter.count('none', 'bar');
-        })
-        .then(function(result) {
+        .then(() => counter.count('none', 'bar'))
+        .then(result => {
           expect(result).to.equal(2);
           return counter.count('year', 'bar');
         })
-        .then(function(result) {
-          expect(result).to.equal(1);
-        });
+        .then(result => expect(result).to.equal(1));
     });
   });
 
-  describe('countRange', function() {
-    it('should return a range of counts', function(done) {
-      var counter = new TimestampedCounter(metrics, 'foo', {
+  describe('countRange', () => {
+    it('should return a range of counts', done => {
+      const counter = new TimestampedCounter(metrics, 'foo', {
         timeGranularity: 'year'
       });
 
       // Increment 2014 once and 2015 twice
 
-      var start = moment.utc({ year: 2014 });
-      var end = moment.utc({ year: 2015 });
-      var expected = {};
+      const start = moment.utc({ year: 2014 });
+      const end = moment.utc({ year: 2015 });
+      const expected = {};
       expected[start.format()] = 1;
       expected[end.format()] = 2;
 
-      var clock = sandbox.useFakeTimers(new Date('2014-02-01').getTime());
+      const clock = sandbox.useFakeTimers(new Date('2014-02-01').getTime());
       counter.incr()
-        .then(function() {
+        .then(() => {
           clock.tick(1000 * 60 * 60 * 24 * 365);
           return counter.incr();
         })
-        .then(function() {
-          return counter.incr();
-        })
-        .then(function() {
-          return counter.countRange('year', start, end);
-        })
-        .then(function(result) {
+        .then(() => counter.incr())
+        .then(() => counter.countRange('year', start, end))
+        .then(result => {
           // Check promise
           expect(result).to.deep.equal(expected);
 
           // Check callback
-          counter.countRange('year', start, end, function(err, res) {
+          counter.countRange('year', start, end, (err, res) => {
             expect(res).to.deep.equal(expected);
             done();
           });
@@ -819,37 +789,33 @@ describe('Counter', function() {
         .catch(done);
     });
 
-    it('should return a range of counts at the second level', function(done) {
-      var counter = new TimestampedCounter(metrics, 'foo', {
+    it('should return a range of counts at the second level', done => {
+      const counter = new TimestampedCounter(metrics, 'foo', {
         timeGranularity: 'second'
       });
 
       // Increment 2014 once and 2015 twice
 
-      var start = moment.utc({ year: 2015, second: 0 });
-      var end = moment.utc({ year: 2015, second: 1 });
-      var expected = {};
+      const start = moment.utc({ year: 2015, second: 0 });
+      const end = moment.utc({ year: 2015, second: 1 });
+      const expected = {};
       expected[start.format()] = 1;
       expected[end.format()] = 2;
 
-      var clock = sandbox.useFakeTimers(new Date('2015-01-01').getTime());
+      const clock = sandbox.useFakeTimers(new Date('2015-01-01').getTime());
       counter.incr()
-        .then(function() {
+        .then(() => {
           clock.tick(1000);
           return counter.incr();
         })
-        .then(function() {
-          return counter.incr();
-        })
-        .then(function() {
-          return counter.countRange('second', start, end);
-        })
-        .then(function(result) {
+        .then(() => counter.incr())
+        .then(() => counter.countRange('second', start, end))
+        .then(result => {
           // Check promise
           expect(result).to.deep.equal(expected);
 
           // Check callback
-          counter.countRange('second', start, end, function(err, res) {
+          counter.countRange('second', start, end, (err, res) => {
             expect(res).to.deep.equal(expected);
             done();
           });
@@ -857,37 +823,33 @@ describe('Counter', function() {
         .catch(done);
     });
 
-    it('should return a range of count for an event object', function(done) {
-      var counter = new TimestampedCounter(metrics, 'foo', {
+    it('should return a range of count for an event object', done => {
+      const counter = new TimestampedCounter(metrics, 'foo', {
         timeGranularity: 'year'
       });
 
       // Increment 2014 once and 2015 twice
 
-      var start = moment.utc({ year: 2014 });
-      var end = moment.utc({ year: 2015 });
-      var expected = {};
+      const start = moment.utc({ year: 2014 });
+      const end = moment.utc({ year: 2015 });
+      const expected = {};
       expected[start.format()] = 1;
       expected[end.format()] = 2;
 
-      var clock = sandbox.useFakeTimers(new Date('2014-02-01').getTime());
+      const clock = sandbox.useFakeTimers(new Date('2014-02-01').getTime());
       counter.incr('bar')
-        .then(function() {
+        .then(() => {
           clock.tick(1000 * 60 * 60 * 24 * 365);
           return counter.incr('bar');
         })
-        .then(function() {
-          return counter.incr('bar');
-        })
-        .then(function() {
-          return counter.countRange('year', start, end, 'bar');
-        })
-        .then(function(result) {
+        .then(() => counter.incr('bar'))
+        .then(() => counter.countRange('year', start, end, 'bar'))
+        .then(result => {
           // Check promise
           expect(result).to.deep.equal(expected);
 
           // Check callback
-          counter.countRange('year', start, end, 'bar', function(err, res) {
+          counter.countRange('year', start, end, 'bar', (err, res) => {
             expect(res).to.deep.equal(expected);
             done();
           });
@@ -895,36 +857,32 @@ describe('Counter', function() {
         .catch(done);
     });
 
-    it('should use current date if no end date is provided', function(done) {
-      var counter = new TimestampedCounter(metrics, 'foo', {
+    it('should use current date if no end date is provided', done => {
+      const counter = new TimestampedCounter(metrics, 'foo', {
         timeGranularity: 'year'
       });
 
       // Increment 2014 once and 2015 twice
 
-      var start = moment.utc({ year: 2014 });
-      var expected = {};
+      const start = moment.utc({ year: 2014 });
+      const expected = {};
       expected[start.format()] = 1;
       expected[moment.utc(start).add(1, 'years').format()] = 2;
 
-      var clock = sandbox.useFakeTimers(new Date('2014-02-01').getTime());
+      const clock = sandbox.useFakeTimers(new Date('2014-02-01').getTime());
       counter.incr()
-        .then(function() {
+        .then(() => {
           clock.tick(1000 * 60 * 60 * 24 * 365);
           return counter.incr();
         })
-        .then(function() {
-          return counter.incr();
-        })
-        .then(function() {
-          return counter.countRange('year', start);
-        })
-        .then(function(result) {
+        .then(() => counter.incr())
+        .then(() => counter.countRange('year', start))
+        .then(result => {
           // Check promise
           expect(result).to.deep.equal(expected);
 
           // Check callback
-          counter.countRange('year', start, function(err, res) {
+          counter.countRange('year', start, (err, res) => {
             expect(res).to.deep.equal(expected);
             done();
           });
@@ -932,30 +890,28 @@ describe('Counter', function() {
         .catch(done);
     });
 
-    it('should return 0 for counters where no data registed', function(done) {
-      var counter = new TimestampedCounter(metrics, 'foo', {
+    it('should return 0 for counters where no data registed', done => {
+      const counter = new TimestampedCounter(metrics, 'foo', {
         timeGranularity: 'year'
       });
 
       // Increment 2014 once.
 
-      var start = moment.utc({ year: 2014 });
-      var end = moment.utc({ year: 2015 });
-      var expected = {};
+      const start = moment.utc({ year: 2014 });
+      const end = moment.utc({ year: 2015 });
+      const expected = {};
       expected[start.format()] = 1;
       expected[end.format()] = 0;
 
       sandbox.useFakeTimers(new Date('2014-02-01').getTime());
       counter.incr()
-        .then(function() {
-          return counter.countRange('year', start, end);
-        })
-        .then(function(result) {
+        .then(() => counter.countRange('year', start, end))
+        .then(result => {
           // Check promise
           expect(result).to.deep.equal(expected);
 
           // Check callback
-          counter.countRange('year', start, end, function(err, res) {
+          counter.countRange('year', start, end, (err, res) => {
             expect(res).to.deep.equal(expected);
             done();
           });
@@ -963,30 +919,28 @@ describe('Counter', function() {
         .catch(done);
     });
 
-    it('should return 0 for counters where no data is reg', function(done) {
-      var counter = new TimestampedCounter(metrics, 'foo', {
+    it('should return 0 for counters where no data is reg', done => {
+      const counter = new TimestampedCounter(metrics, 'foo', {
         timeGranularity: 'year'
       });
 
       // Increment 2014 once.
 
-      var start = moment.utc({ year: 2014 });
-      var end = moment.utc({ year: 2015 });
-      var expected = {};
+      const start = moment.utc({ year: 2014 });
+      const end = moment.utc({ year: 2015 });
+      const expected = {};
       expected[start.format()] = 1;
       expected[end.format()] = 0;
 
       sandbox.useFakeTimers(new Date('2014-02-01').getTime());
       counter.incr('bar')
-        .then(function() {
-          return counter.countRange('year', start, end, 'bar');
-        })
-        .then(function(result) {
+        .then(() => counter.countRange('year', start, end, 'bar'))
+        .then(result => {
           // Check promise
           expect(result).to.deep.equal(expected);
 
           // Check callback
-          counter.countRange('year', start, end, 'bar', function(err, res) {
+          counter.countRange('year', start, end, 'bar', (err, res) => {
             expect(res).to.deep.equal(expected);
             done();
           });
@@ -994,40 +948,36 @@ describe('Counter', function() {
         .catch(done);
     });
 
-    it('should accept strings for date range', function(done) {
-      var counter = new TimestampedCounter(metrics, 'foo', {
+    it('should accept strings for date range', done => {
+      const counter = new TimestampedCounter(metrics, 'foo', {
         timeGranularity: 'year'
       });
 
       // Increment 2014 once and 2015 twice
 
-      var start = moment.utc({ year: 2014 });
-      var end = moment.utc({ year: 2015 });
-      var expected = {};
+      const start = moment.utc({ year: 2014 });
+      const end = moment.utc({ year: 2015 });
+      const expected = {};
       expected[start.format()] = 1;
       expected[end.format()] = 2;
 
-      var startStr = '2014-01-01T00:00:00Z';
-      var endStr = '2015-01-01T00:00:00Z';
+      const startStr = '2014-01-01T00:00:00Z';
+      const endStr = '2015-01-01T00:00:00Z';
 
-      var clock = sandbox.useFakeTimers(new Date('2014-02-01').getTime());
+      const clock = sandbox.useFakeTimers(new Date('2014-02-01').getTime());
       counter.incr()
-        .then(function() {
+        .then(() => {
           clock.tick(1000 * 60 * 60 * 24 * 365);
           return counter.incr();
         })
-        .then(function() {
-          return counter.incr();
-        })
-        .then(function() {
-          return counter.countRange('year', startStr, endStr);
-        })
-        .then(function(result) {
+        .then(() => counter.incr())
+        .then(() => counter.countRange('year', startStr, endStr))
+        .then(result => {
           // Check promise
           expect(result).to.deep.equal(expected);
 
           // Check callback
-          counter.countRange('year', startStr, endStr, function(err, res) {
+          counter.countRange('year', startStr, endStr, (err, res) => {
             expect(res).to.deep.equal(expected);
             done();
           });
@@ -1035,40 +985,36 @@ describe('Counter', function() {
         .catch(done);
     });
 
-    it('should accept numbers for date range', function(done) {
-      var counter = new TimestampedCounter(metrics, 'foo', {
+    it('should accept numbers for date range', done => {
+      const counter = new TimestampedCounter(metrics, 'foo', {
         timeGranularity: 'year'
       });
 
       // Increment 2014 once and 2015 twice
 
-      var start = moment.utc({ year: 2014 });
-      var end = moment.utc({ year: 2015 });
-      var expected = {};
+      const start = moment.utc({ year: 2014 });
+      const end = moment.utc({ year: 2015 });
+      const expected = {};
       expected[start.format()] = 1;
       expected[end.format()] = 2;
 
-      var startNum = start.valueOf();
-      var endNum = end.valueOf();
+      const startNum = start.valueOf();
+      const endNum = end.valueOf();
 
-      var clock = sandbox.useFakeTimers(new Date('2014-02-01').getTime());
+      const clock = sandbox.useFakeTimers(new Date('2014-02-01').getTime());
       counter.incr()
-        .then(function() {
+        .then(() => {
           clock.tick(1000 * 60 * 60 * 24 * 365);
           return counter.incr();
         })
-        .then(function() {
-          return counter.incr();
-        })
-        .then(function() {
-          return counter.countRange('year', startNum, endNum);
-        })
-        .then(function(result) {
+        .then(() => counter.incr())
+        .then(() => counter.countRange('year', startNum, endNum))
+        .then(result => {
           // Check promise
           expect(result).to.deep.equal(expected);
 
           // Check callback
-          counter.countRange('year', startNum, endNum, function(err, res) {
+          counter.countRange('year', startNum, endNum, (err, res) => {
             expect(res).to.deep.equal(expected);
             done();
           });
@@ -1076,34 +1022,30 @@ describe('Counter', function() {
         .catch(done);
     });
 
-    it('should return a single num if total gran is selected', function(done) {
-      var counter = new TimestampedCounter(metrics, 'foo', {
+    it('should return a single num if total gran is selected', done => {
+      const counter = new TimestampedCounter(metrics, 'foo', {
         timeGranularity: 'year'
       });
 
       // Increment 2014 once and 2015 twice => total is 3
 
-      var start = moment.utc({ year: 2014 });
-      var end = moment.utc({ year: 2015 });
+      const start = moment.utc({ year: 2014 });
+      const end = moment.utc({ year: 2015 });
 
-      var clock = sandbox.useFakeTimers(new Date('2014-02-01').getTime());
+      const clock = sandbox.useFakeTimers(new Date('2014-02-01').getTime());
       counter.incr()
-        .then(function() {
+        .then(() => {
           clock.tick(1000 * 60 * 60 * 24 * 365);
           return counter.incr();
         })
-        .then(function() {
-          return counter.incr();
-        })
-        .then(function() {
-          return counter.countRange('total', start, end);
-        })
-        .then(function(result) {
+        .then(() => counter.incr())
+        .then(() => counter.countRange('total', start, end))
+        .then(result => {
           // Check promise
           expect(result).to.equal(3);
 
           // Check callback
-          counter.countRange('total', start, end, function(err, res) {
+          counter.countRange('total', start, end, (err, res) => {
             expect(res).to.equal(3);
             done();
           });
@@ -1111,30 +1053,28 @@ describe('Counter', function() {
         .catch(done);
     });
 
-    it('should throw an exc if countRange is used on a counter', function() {
-      var counter = new TimestampedCounter(metrics, 'foo', {
+    it('should throw an exc if countRange is used on a counter', () => {
+      const counter = new TimestampedCounter(metrics, 'foo', {
         timeGranularity: 'total'
       });
 
-      var throwClosure = function() {
-        counter.countRange('total', '2015', '2016');
-      };
+      const throwClosure = () => counter.countRange('total', '2015', '2016');
       expect(throwClosure).to.throw(Error);
     });
   });
 
-  describe('incr with expiration', function() {
-    it('should set a ttl for a key', function(done) {
-      var counter = new TimestampedCounter(metrics, 'foo', {
+  describe('incr with expiration', () => {
+    it('should set a ttl for a key', done => {
+      const counter = new TimestampedCounter(metrics, 'foo', {
         expireKeys: true,
         expiration: {
           total: 100
         }
       });
 
-      counter.incr().then(function() {
-        var key = counter.getKeys()[0];
-        metrics.client.ttl(key, function(err, ttl) {
+      counter.incr().then(() => {
+        const key = counter.getKeys()[0];
+        metrics.client.ttl(key, (err, ttl) => {
           expect(err).to.equal(null);
           expect(ttl).to.be.above(0);
           expect(ttl).to.be.most(100);
@@ -1144,17 +1084,17 @@ describe('Counter', function() {
       .catch(done);
     });
 
-    it('should set a ttl for a key with event objects', function(done) {
-      var counter = new TimestampedCounter(metrics, 'foo', {
+    it('should set a ttl for a key with event objects', done => {
+      const counter = new TimestampedCounter(metrics, 'foo', {
         expireKeys: true,
         expiration: {
           total: 100
         }
       });
 
-      counter.incr('bar').then(function() {
-        var key = counter.getKeys()[0] + ':z';
-        metrics.client.ttl(key, function(err, ttl) {
+      counter.incr('bar').then(() => {
+        const key = counter.getKeys()[0] + ':z';
+        metrics.client.ttl(key, (err, ttl) => {
           expect(err).to.equal(null);
           expect(ttl).to.be.above(0);
           expect(ttl).to.be.most(100);
@@ -1164,20 +1104,20 @@ describe('Counter', function() {
       .catch(done);
     });
 
-    it('should not renew the ttl on the second call', function(done) {
-      var counter = new TimestampedCounter(metrics, 'foo', {
+    it('should not renew the ttl on the second call', done => {
+      const counter = new TimestampedCounter(metrics, 'foo', {
         expireKeys: true,
         expiration: {
           total: 100
         }
       });
 
-      counter.incr().then(function() {
-        var key = counter.getKeys()[0];
-        metrics.client.ttl(key, function(err, ttl) {
-          setTimeout(function() {
-            counter.incr().then(function() {
-              metrics.client.ttl(key, function(err2, ttl2) {
+      counter.incr().then(() => {
+        const key = counter.getKeys()[0];
+        metrics.client.ttl(key, (err, ttl) => {
+          setTimeout(() => {
+            counter.incr().then(() => {
+              metrics.client.ttl(key, (err2, ttl2) => {
                 // Expect that ttl has decreased.
                 console.log(ttl, ttl2);
                 expect(ttl2).to.be.below(ttl);
@@ -1191,20 +1131,20 @@ describe('Counter', function() {
       .catch(done);
     });
 
-    it('should not renew the ttl on the second call', function(done) {
-      var counter = new TimestampedCounter(metrics, 'foo', {
+    it('should not renew the ttl on the second call', done => {
+      const counter = new TimestampedCounter(metrics, 'foo', {
         expireKeys: true,
         expiration: {
           total: 100
         }
       });
 
-      counter.incr('bar').then(function() {
-        var key = counter.getKeys()[0] + ':z';
-        metrics.client.ttl(key, function(err, ttl) {
-          setTimeout(function() {
-            counter.incr('bar').then(function() {
-              metrics.client.ttl(key, function(err2, ttl2) {
+      counter.incr('bar').then(() => {
+        const key = counter.getKeys()[0] + ':z';
+        metrics.client.ttl(key, (err, ttl) => {
+          setTimeout(() => {
+            counter.incr('bar').then(() => {
+              metrics.client.ttl(key, (err2, ttl2) => {
                 // Expect that ttl has decreased.
                 console.log(ttl, ttl2);
                 expect(ttl2).to.be.below(ttl);
@@ -1219,18 +1159,18 @@ describe('Counter', function() {
     });
   });
 
-  describe('incrby with expiration', function() {
-    it('should set a ttl for a key', function(done) {
-      var counter = new TimestampedCounter(metrics, 'foo', {
+  describe('incrby with expiration', () => {
+    it('should set a ttl for a key', done => {
+      const counter = new TimestampedCounter(metrics, 'foo', {
         expireKeys: true,
         expiration: {
           total: 60 // Gone in 60 seconds :-)
         }
       });
 
-      counter.incrby(10).then(function() {
-        var key = counter.getKeys()[0];
-        metrics.client.ttl(key, function(err, ttl) {
+      counter.incrby(10).then(() => {
+        const key = counter.getKeys()[0];
+        metrics.client.ttl(key, (err, ttl) => {
           expect(err).to.equal(null);
           expect(ttl).to.be.above(0);
           expect(ttl).to.be.most(60);
@@ -1240,17 +1180,17 @@ describe('Counter', function() {
       .catch(done);
     });
 
-    it('should set a ttl for a key with event objects', function(done) {
-      var counter = new TimestampedCounter(metrics, 'foo', {
+    it('should set a ttl for a key with event objects', done => {
+      const counter = new TimestampedCounter(metrics, 'foo', {
         expireKeys: true,
         expiration: {
           total: 100
         }
       });
 
-      counter.incrby(10, 'bar').then(function() {
-        var key = counter.getKeys()[0] + ':z';
-        metrics.client.ttl(key, function(err, ttl) {
+      counter.incrby(10, 'bar').then(() => {
+        const key = counter.getKeys()[0] + ':z';
+        metrics.client.ttl(key, (err, ttl) => {
           expect(err).to.equal(null);
           expect(ttl).to.be.above(0);
           expect(ttl).to.be.most(100);
@@ -1261,16 +1201,16 @@ describe('Counter', function() {
     });
   });
 
-  describe('top', function() {
-    it('should work with callback', function(done) {
-      var mock = sandbox.mock(metrics.client)
+  describe('top', () => {
+    it('should work with callback', done => {
+      const mock = sandbox.mock(metrics.client)
         .expects('zrevrange')
         .once()
         .withArgs('c:foo:z', 0, -1, 'WITHSCORES')
         .yields(null, ['foo', '39', 'bar', '13']);
 
-      var counter = new TimestampedCounter(metrics, 'foo');
-      counter.top('foo', function(err, results) {
+      const counter = new TimestampedCounter(metrics, 'foo');
+      counter.top('foo', (err, results) => {
         mock.verify();
         expect(results).to.have.length(2);
         expect(results[0]).to.have.property('foo');
@@ -1279,15 +1219,15 @@ describe('Counter', function() {
       });
     });
 
-    it('should work with promises', function(done) {
-      var mock = sandbox.mock(metrics.client)
+    it('should work with promises', done => {
+      const mock = sandbox.mock(metrics.client)
         .expects('zrevrange')
         .once()
         .yields(null, ['foo', '39', 'bar', '13']);
 
-      var counter = new TimestampedCounter(metrics, 'foo');
+      const counter = new TimestampedCounter(metrics, 'foo');
       counter.top('foo')
-        .then(function(results) {
+        .then(results => {
           mock.verify();
           expect(results).to.have.length(2);
           expect(results[0]).to.have.property('foo');
@@ -1297,51 +1237,51 @@ describe('Counter', function() {
         .catch(done);
     });
 
-    it('should accept a startingAt argument', function(done) {
-      var mock = sandbox.mock(metrics.client)
+    it('should accept a startingAt argument', done => {
+      const mock = sandbox.mock(metrics.client)
         .expects('zrevrange')
         .once()
         .withArgs('c:foo:z', 10, -1, 'WITHSCORES')
         .yields(null, ['foo', '39', 'bar', '13']);
 
-      var counter = new TimestampedCounter(metrics, 'foo');
-      counter.top('foo', 'desc', 10, function(err) {
+      const counter = new TimestampedCounter(metrics, 'foo');
+      counter.top('foo', 'desc', 10, err => {
         mock.verify();
         done(err);
       });
     });
 
-    it('should accept a startingAt and a limit argument', function(done) {
-      var mock = sandbox.mock(metrics.client)
+    it('should accept a startingAt and a limit argument', done => {
+      const mock = sandbox.mock(metrics.client)
         .expects('zrevrange')
         .once()
         .withArgs('c:foo:z', 10, 15, 'WITHSCORES')
         .yields(null, ['foo', '39', 'bar', '13']);
 
-      var counter = new TimestampedCounter(metrics, 'foo');
-      counter.top('foo', 'desc', 10, 15, function(err) {
+      const counter = new TimestampedCounter(metrics, 'foo');
+      counter.top('foo', 'desc', 10, 15, err => {
         mock.verify();
         done(err);
       });
     });
 
-    it('should accept a direction argument with asc value', function(done) {
-      var mock = sandbox.mock(metrics.client)
+    it('should accept a direction argument with asc value', done => {
+      const mock = sandbox.mock(metrics.client)
         .expects('zrange')
         .once()
         .withArgs('c:foo:z', 0, -1, 'WITHSCORES')
         .yields(null, ['foo', '39', 'bar', '13']);
 
-      var counter = new TimestampedCounter(metrics, 'foo');
-      counter.top('foo', 'asc', function(err) {
+      const counter = new TimestampedCounter(metrics, 'foo');
+      counter.top('foo', 'asc', err => {
         mock.verify();
         done(err);
       });
     });
 
     it('should throw an exception if the direction argument is not correct',
-      function(done) {
-        var counter = new TimestampedCounter(metrics, 'foo');
+      done => {
+        const counter = new TimestampedCounter(metrics, 'foo');
         try {
           counter.top('foo', 'dummy');
         } catch (e) {

--- a/test/metrics.js
+++ b/test/metrics.js
@@ -1,38 +1,32 @@
 'use strict';
 
-var redis = require('redis'),
+const redis = require('redis'),
   sinon = require('sinon'),
   chai = require('chai'),
   RedisMetrics = require('../lib/metrics'),
   TimestampedCounter = require('../lib/counter');
 
-var expect = chai.expect;
+const expect = chai.expect;
 
-describe('Metric main', function() {
+describe('Metric main', () => {
 
-  var sandbox;
-  beforeEach(function() {
+  let sandbox;
+  beforeEach(() => {
     sandbox = sinon.sandbox.create();
   });
 
-  afterEach(function() {
+  afterEach(() => {
     sandbox.restore();
   });
 
-  describe('constructor', function() {
-    it('should create an instance with new keyword', function() {
-      var metrics = new RedisMetrics();
+  describe('constructor', () => {
+    it('should create an instance with new keyword', () => {
+      const metrics = new RedisMetrics();
       expect(metrics).to.be.instanceof(RedisMetrics);
     });
 
-    it('should create an instance without new keyword', function() {
-      // This is not encouraged though :-)
-      var metrics = require('../lib/metrics')();
-      expect(metrics).to.be.instanceof(RedisMetrics);
-    });
-
-    it('should create a redis client', function() {
-      var mock = sandbox.mock(redis)
+    it('should create a redis client', () => {
+      const mock = sandbox.mock(redis)
         .expects('createClient')
         .once()
         .withExactArgs();
@@ -40,8 +34,8 @@ describe('Metric main', function() {
       mock.verify();
     });
 
-    it('should create a redis client with host and port if passed', function() {
-      var mock = sandbox.mock(redis)
+    it('should create a redis client with host and port if passed', () => {
+      const mock = sandbox.mock(redis)
         .expects('createClient')
         .once()
         .withExactArgs(1234, 'abcd', {});
@@ -49,11 +43,11 @@ describe('Metric main', function() {
       mock.verify();
     });
 
-    it('should create a redis client with options if provided', function() {
+    it('should create a redis client with options if provided', () => {
       // jscs:disable requireCamelCaseOrUpperCaseIdentifiers
-      var redisOpts = { no_ready_check: true };
+      const redisOpts = { no_ready_check: true };
 
-      var mock = sandbox.mock(redis)
+      const mock = sandbox.mock(redis)
         .expects('createClient')
         .once()
         .withExactArgs(redisOpts);
@@ -61,10 +55,10 @@ describe('Metric main', function() {
       mock.verify();
     });
 
-    it('should recycle the client if passed as an option', function() {
-      var client = redis.createClient();
+    it('should recycle the client if passed as an option', () => {
+      const client = redis.createClient();
 
-      var mock = sandbox.mock(redis)
+      const mock = sandbox.mock(redis)
         .expects('createClient')
         .never();
 
@@ -73,33 +67,31 @@ describe('Metric main', function() {
     });
   });
 
-  describe('counter', function() {
-    var metrics;
-    beforeEach(function() {
-      metrics = new RedisMetrics();
-    });
+  describe('counter', () => {
+    let metrics;
+    beforeEach(() => metrics = new RedisMetrics());
 
-    it('should return a counter for a key', function() {
-      var counter = metrics.counter('foo');
+    it('should return a counter for a key', () => {
+      const counter = metrics.counter('foo');
       expect(counter).to.be.instanceof(TimestampedCounter);
     });
 
-    it('should pass the options object to the counter constructor', function() {
-      var options = {
+    it('should pass the options object to the counter constructor', () => {
+      const options = {
         timeGranularity: 1
       };
-      var counter = metrics.counter('foo', options);
+      const counter = metrics.counter('foo', options);
       expect(counter.options.timeGranularity).to.equal(1);
     });
 
-    it('should use the default options when none are provided', function() {
+    it('should use the default options when none are provided', () => {
       metrics = new RedisMetrics({
         counterOptions: {
           timeGranularity: 2
         }
       });
 
-      var counter = metrics.counter('foo');
+      const counter = metrics.counter('foo');
       expect(counter.options.timeGranularity).to.equal(2);
     });
   });


### PR DESCRIPTION
This commit updates all code with ES6 features, specifically:
- Arrow-functions instead of `function`
- `const` and `let` instead of `var`
- Native `Promise` instead of `Q`

This update thus deprecates support for Node versions below 4.