### PR TITLE
Add function for removing counter event objects

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -15,5 +15,6 @@
         "beforeOpeningRoundBrace": true
     },
     "requireSpacesInAnonymousFunctionExpression": null,
-    "maximumLineLength": 100
+    "maximumLineLength": 100,
+    "requireShorthandArrowFunctions": false
 }

--- a/lib/counter.js
+++ b/lib/counter.js
@@ -53,6 +53,33 @@ const parseTimeGranularity = timeGranularity => {
 };
 
 /**
+ * Return a list of Redis keys that are associated with this counter at the
+ * current point in time and will be written to Redis.
+ * @param {String} baseKey - The base key to use.
+ * @param {String} formattedTimestamp - A formatted timestamp string.
+ * @param {module:constants~timeGranularities} timeGranularity - The
+ *   granularity level to return keys for.
+ * @returns {Array} Contains the counter keys for the given timestamp.
+ * @private
+ */
+const getKeys = (baseKey, formattedTimestamp, timeGranularity) => {
+  // Always add the baseKey itself.
+  const keys = [baseKey];
+
+  // If no time granularity is chosen, the timestamped keys will not be used so
+  // just return the default key.
+  if (timeGranularity === timeGranularities.none) {
+    return keys;
+  }
+
+  for (let i = 1; i <= timeGranularity; i++) {
+    keys.push(`${baseKey}:${formattedTimestamp.slice(0, i * 2 + 2)}`);
+  }
+
+  return keys;
+};
+
+/**
  * Creates a function that parses a list of Redis results and matches them up
  * with the given keyRange
  * @param {array} keyRange - The list of keys to match with the results.
@@ -98,6 +125,7 @@ const incrSingle = (client, key, amount, eventObj, ttl, cb) => {
  * Parse a rank result from redis
  * @param  {array} rank In this format: [ 'foo', '39', 'bar', '13' ]
  * @return {object} In this format: [ { foo: 39 }, { bar: 13 } ]
+ * @private
  */
 const rankParser = rank => {
   // groups the array for each second row
@@ -156,24 +184,19 @@ class TimestampedCounter {
 
   /**
    * Return a list of Redis keys that are associated with this counter at the
-   * current point in time and will be written to Redis.
+   * current point in time (default) and will be written to Redis.
+   * @param {Moment} [time=now] - A specific time to get keys for.
+   * @param {module:constants~timeGranularities} [timeGranularity] - The
+   *   granularity level to return keys for. The default is the granularity from
+   *   the options.
    * @returns {Array}
    */
-  getKeys() {
-    // Always add the key itself.
-    const keys = [this.key];
-
-    // If no time granularity is chosen, the timestamped keys will not be used so
-    // just return the default key.
-    if (this.options.timeGranularity === timeGranularities.none) {
-      return keys;
-    }
-
-    const now = moment.utc().format(momentFormat);
-    for (let i = 1; i <= this.options.timeGranularity; i++) {
-      keys.push(this.key + ':' + now.slice(0, i * 2 + 2));
-    }
-    return keys;
+  getKeys(time, timeGranularity) {
+    return getKeys(
+      this.key,
+      (time || moment.utc()).format(momentFormat),
+      parseTimeGranularity(timeGranularity) || this.options.timeGranularity
+    );
   }
 
   /**
@@ -436,9 +459,9 @@ class TimestampedCounter {
    *
    * @param {module:constants~timeGranularities} [timeGranularity='total'] - The
    *   granularity level to report the rank for.
-   * @param {string} [direction] - Optional sort direction, can be "asc" or "desc"
-   * @param {integer} [startingAt] - Optional starting row, default 0
-   * @param {integer} [limit] - Optional number of results to return, default -1
+   * @param {string} [direction=desc] - Optional sort direction, can be "asc" or "desc"
+   * @param {integer} [startingAt=0] - Optional starting row.
+   * @param {integer} [limit=-1] - Optional number of results to return.
    * @param {function} [callback] - Optional callback.
    * @returns {Promise} A promise that resolves to the result from Redis. Can
    *   be used instead of the callback function.
@@ -489,6 +512,99 @@ class TimestampedCounter {
       'WITHSCORES',
       cb
     );
+  }
+
+  /**
+   * Permanently remove event objects for this counter so only the top-N
+   * elements remain in either descending (the default) or ascending order.
+   *
+   * The event objects are removed with Redis' removal by rank for sorted sets
+   * ({@link https://redis.io/commands/zremrangebyrank|ZREMRANGEBYRANK}).
+   *
+   * The removal happens at each granularity level and only supports daily
+   * granularity and above (month, year, total) to optimize for the number of
+   * Redis keys to consider. It removes data going 5 years back in time.
+   *
+   * If the function is used too often, there is a risk that the top-N elements
+   * will stay the same forever, because lower-ranking elements get removed
+   * before their scores have a change to increase.
+   *
+   * Therefore, the function should only be used to try and reclaim space for
+   * big counters with a lot of event objects, and only rarely used.
+   *
+   * @param {string} [keepDirection=desc] - Sort direction for the top-N
+   * elements to keep, can be "asc" or "desc".
+   * @param {integer} [limit=1000] - Number of results to keep.
+   * @param {function} [callback] - Callback
+   * @returns {Promise} Resolves when the values have been removed.
+   * @example
+   * // Keeps the top-5 elements with highest score
+   * myCounter.trimEvents('desc', 5)
+   * @example
+   * // Keeps the top-5 elements with lowest score
+   * myCounter.trimEvents('asc', 5)
+   * @since 1.1.0
+   */
+  trimEvents(keepDirection, limit, callback) {
+    const args = Array.prototype.slice.call(arguments);
+    callback = typeof args[args.length - 1] === 'function' ? args.pop() : null;
+    limit = args.length > 1 ? args.pop() : 1000;
+    keepDirection = args.length > 0 ? args.pop() : 'desc';
+
+    if (['asc', 'desc'].indexOf(keepDirection) === -1) {
+      throw new Error(
+        'The keepDirection parameter is expected to be one between ' +
+        '"asc" or "desc", got "' + keepDirection + '".'
+      );
+    }
+
+    // If we want to keep top-5 lowest scores, remove rank 5 to -1
+    // If we want to keep top-5 highest scores, remove rank 0 to -(5 + 1)
+    const startIndex = keepDirection === 'asc' ? limit : 0;
+    const endIndex = keepDirection === 'asc' ? -1 : -(limit + 1);
+
+    const deferred = utils.defer();
+    const cb = utils.createRedisCallback(deferred, callback);
+
+    // If the counter does not have a time granularity, our job is easy.
+    if (this.options.timeGranularity === timeGranularities.none) {
+      this.metrics.client.zremrangebyrank(`${this.key}:z`, startIndex, endIndex, cb);
+      return deferred.promise;
+    }
+
+    // Otherwise trim keys for the last five years.
+    const currentTime = moment.utc().subtract(5, 'year')
+      .startOf('year')
+      .startOf('day');
+    const end = moment.utc();
+    const keySet = new Set();
+    while (currentTime.isBefore(end)) {
+      for (const key of this.getKeys(currentTime, timeGranularities.day)) {
+        keySet.add(key);
+      }
+
+      // Mutates the time.
+      currentTime.add(1, 'day');
+    }
+
+    // Each key is mapped to a function that returns a Promise.
+    const mappedPromiseFunctions = Array.from(keySet).map(key => {
+      return () => {
+        const subDeferred = utils.defer();
+        const subCallback = utils.createRedisCallback(subDeferred);
+        this.metrics.client.zremrangebyrank(`${key}:z`, startIndex, endIndex, subCallback);
+        return subDeferred.promise;
+      };
+    });
+
+    // Each function is executed sequentially using reduce.
+    mappedPromiseFunctions.reduce((promise, f) => {
+      return promise.then(totalRemoved => f().then(removed => totalRemoved + removed));
+    }, Promise.resolve(0))
+    .then(totalRemoved => cb(null, totalRemoved))
+    .catch(err => cb(err));
+
+    return deferred.promise;
   }
 }
 


### PR DESCRIPTION
This PR adds a utility function to the timestamped counter that can trim the set of event objects stored for the counter. This is useful if the number of event objects have gotten very large, but it is not generally a good idea to use the function very often, because it naively trims values without considering the impact to reporting.