### PR TITLE
Spring Cleaning

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,4 @@
+{
+  "root": true,
+  "extends": ["conversio"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ pids
 lib-cov
 
 # Coverage directory used by tools like istanbul
-coverage
+.nyc_output/
 
 # Grunt intermediate storage (http://gruntjs.com/creating-plugins#storing-task-files)
 .grunt

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ lib-cov
 
 # Coverage directory used by tools like istanbul
 .nyc_output/
+coverage.lcov
 
 # Grunt intermediate storage (http://gruntjs.com/creating-plugins#storing-task-files)
 .grunt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
-- '4'
 - '6'
 - '8'
+- '10'
 services:
 - redis-server
 before_script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+## v2.0.0
+
+### Breaking Changes
+
+* Removed support for Node 4
+* Removed callback interface
+* Changed counter method interfaces from optional arguments to an options argument, where applicable:
+  * `incr` receives an option object with the `eventObj` as a key.
+  * `incrby` same as `incr` on the last argument.
+  * `count` receives all previous arguments as a single option object.
+  * `countRange` still gets `timeGranularity` as a first argument, but range dates are passed on a single second argument, and the `eventObj` is passed within an optional third argument object.
+  * `top` receives all previous arguments as a single option object.
+  * `topRange` same as `countRange` for range dates, and all arguments go onto the last optional argument.
+  * `trimEvents` same as `count`.
+  * `zero` same as `incr`.
+
+### Other Changes
+
+* Changed linting tools and configs

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-redis-metrics
-=============
+# redis-metrics 📈
 
 Easy metric tracking and aggregation using Redis.
 
@@ -15,36 +14,81 @@ Read on below or read more on the [documentation site](http://getconversio.githu
 [![Build Status](https://travis-ci.org/getconversio/redis-metrics.svg?branch=master)](https://travis-ci.org/getconversio/redis-metrics)
 [![codecov](https://codecov.io/gh/getconversio/redis-metrics/branch/master/graph/badge.svg)](https://codecov.io/gh/getconversio/redis-metrics)
 
-Install
--------
+## Install
 
 ```console
 $ npm install --save redis-metrics
 ```
 
-Use
------ 
+## API
 
-Basic counter:
+#### `RedisMetrics`
+
+##### `new RedisMetrics({ client, host, port, redisOptions, counterOptions })`
+
+Instances a new RedisMetrics instance with the given redis configuration. You can pass your own redis client or a host & port for a lib-managed connection.
+
+##### `metrics.counter(eventName, { timeGranularity = 'none', expireKeys = true })`
+
+Creates a new `TimestampedCounter`. The default options create a simple counter with no time granularity (basically, a total count only) that expires its keys automatically.
+
+**`timeGranularity`:** can be one of 'none', 'year', 'month', 'day', 'hour', 'minute', 'second'. This indicates the minimum granularity for which to store individual counters. The more granular, the more memory used, and the quicker the expiration (if enabled).
+
+#### `TimestampedCounter`
+
+##### `counter.incr({ eventObj = null } = { })`
+
+Increments a single counter by 1. An optional `eventObj` can be passed to increment a counter
+for a specific event attribute. This enables using the `top` and `topRange` functions.
+
+##### `counter.incrby(amount, { eventObj = null } = { })`
+
+Same as `counter.incr` for > 1 increments.
+
+##### `counter.count({ timeGranularity = 'total', eventObj = null })`
+
+Returns the current count for this counter. Returns the total by default, but can return results for the current 'year', 'month', etc. Can optionally return results for a single `eventObj`.
+
+##### `counter.countRange(timeGranularity, { startDate, endDate = new Date() }, { eventObj = null })`
+
+Returns a timeseries of the current counts in the given granularity. Requires a `startDate` from which to start counting.
+
+##### `counter.top({ timeGranularity = 'total', direction = 'desc', startingAt = 0, limit = -1 })`
+
+Returns the list of top `eventObj` and their counts. By default, an all-time toplist is returned in descending order, and all event objects are included.
+
+**`startingAt`:** specify a number of top scorers to skip
+**`limit`:** specify to limit how many event objects & counts to return
+
+##### `counter.topRange({ startDate, endDate }, { timeGranularity = 'total', direction = 'desc', startingAt = 0, limit = -1 })`
+
+When given the `total` granularity, acts as `counter.top` but limits the results to the given time range. When given any other granularity, returns a timeseries of toplists for that granularity.
+
+##### `counter.trimEvents({ direction = 'desc', limit = 1000 })`
+
+Keeps only the top `limit` event objects for a given counter.
+
+##### `counter.zero({ eventObj = null })`
+
+Wipes all counters going back 5 years.
+
+## Examples
+
+### Basic counter
 
 ```javascript
 // Create an instance
-var RedisMetrics = require('redis-metrics');
-var metrics = new RedisMetrics();
+const RedisMetrics = require('redis-metrics');
+const metrics = new RedisMetrics();
 
 // If you need to catch uncaught exceptions, add an error handler to the client.
-metrics.client.on('error', function(err) { ... });
+metrics.client.on('error', function(err) { /* ... */ });
 
 // Create a counter for a "pageview" event and increment it three times.
-var myCounter = metrics.counter('pageview');
+const myCounter = metrics.counter('pageview');
 myCounter.incr();
 myCounter.incr();
 myCounter.incr();
-
-// Fetch the count for myCounter, using a callback.
-myCounter.count(function(cnt) {
-  console.log(cnt); // Outputs 3 to the console.
-});
 
 // Fetch the count for myCounter, using promise.
 myCounter.count().then(function(cnt) {
@@ -52,32 +96,32 @@ myCounter.count().then(function(cnt) {
 });
 ```
 
-Time-aware counter.
+### Time-aware counter
 
 ```javascript
-// Create an instance
-var RedisMetrics = require('redis-metrics');
-var metrics = new RedisMetrics();
-
-// If you need to catch uncaught exceptions, add an error handler to the client.
-metrics.client.on('error', function(err) { ... });
+const RedisMetrics = require('redis-metrics');
+const metrics = new RedisMetrics();
 
 // Use the timeGranularity option to specify how specific the counter should be
 // when incrementing.
-var myCounter = metrics.counter('pageview', { timeGranularity: 'hour' });
+const myCounter = metrics.counter('pageview', { timeGranularity: 'hour' });
+myCounter.incr();
+myCounter.incr();
+myCounter.incr();
 
 // Fetch the count for myCounter for the current year.
-myCounter.count('year')
+myCounter.count({ timeGranularity: 'year' })
   .then(function(cnt) {
     console.log(cnt); // Outputs 3 to the console.
   });
 
 // Fetch the count for each of the last two hours.
 // We are using moment here for convenience.
-var moment = require('moment');
-var now = moment();
-var lastHour = moment(now).subtract(1, 'hours');
-myCounter.countRange('hour', lastHour, now)
+const moment = require('moment');
+const now = moment();
+const lastHour = moment(now).subtract(1, 'hours');
+
+myCounter.countRange('hour', { startDate: lastHour })
   .then(function(obj) {
     // "obj" is an object with timestamps as keys and counts as values.
     // For example something like this:
@@ -88,8 +132,8 @@ myCounter.countRange('hour', lastHour, now)
   });
 
 // Fetch the count for each day in the last 30 days
-var thirtyDaysAgo = moment(now).subtract(30, 'days');
-myCounter.countRange('day', thirtyDaysAgo, now)
+const thirtyDaysAgo = moment(now).subtract(30, 'days');
+myCounter.countRange('day', { startDate: thirtyDaysAgo })
   .then(function(obj) {
     // "obj" contains counter information for each of the last thirty days.
     // For example something like this:
@@ -106,22 +150,79 @@ myCounter.countRange('day', thirtyDaysAgo, now)
 // the hour.
 ```
 
-Redis Namespace
-----
+### Event Objects
+
+```javascript
+const myCounter = metrics.counter('pageview', { timeGranularity: 'hour' });
+
+// You may want to get specific when counting an event. Use the `eventObj` option
+// to store individual counters for different event attributes:
+myCounter.incrby(2, { eventObj: '/page1.html' });
+myCounter.incrby(5, { eventObj: '/page2.html' });
+myCounter.incrby(8, { eventObj: '/page3.html' });
+
+myCounter.count({ eventObj: '/page2.html' })
+  .then(count => {
+    console.log(count); // Outputs 5 to the console.
+  });
+```
+
+### Top Event Object Counts
+
+```javascript
+const myCounter = metrics.counter('pageview', { timeGranularity: 'hour' });
+
+// You may want to get specific when counting an event. Use the `eventObj` option
+// to store individual counters for different event attributes:
+myCounter.incrby(2, { eventObj: '/page1.html' });
+myCounter.incrby(5, { eventObj: '/page2.html' });
+myCounter.incrby(8, { eventObj: '/page3.html' });
+
+myCounter.top()
+  .then(toplist => {
+    // toplist:
+    // [
+    //   { '/page3.html': 8 },
+    //   { '/page2.html': 5 },
+    //   { '/page1.html': 2 }
+    // ]
+  });
+
+// a few months later...
+myCounter.incrby(5, { eventObj: '/page1.html' });
+myCounter.incrby(3, { eventObj: '/page2.html' });
+
+myCounter.topRange({ startDate: moment().subtract(1, 'month') })
+  .then(toplist => {
+    // toplist:
+    // [
+    //   { '/page1.html': 5 },
+    //   { '/page2.html': 3 }
+    // ]
+  });
+
+```
+
+## Redis Namespace
+
 By default keys are stored in Redis as `c:{name}:{period}`. If you prefer to use a different Redis namespace than `c`, you can pass this in as an option:
+
 ```
-var myCounter = metrics.counter('pageview', { timeGranularity: 'hour', namespace: 'stats' });`
+const myCounter = metrics.counter('pageview', { timeGranularity: 'hour', namespace: 'stats' });`
 ```
 
+## V2
 
-Test
-----
+See the [changelog](CHANGELOG.md).
+
+## Test
+
 Run tests including code coverage:
 
     $ npm test
 
-Documentation
--------------
+## Documentation
+
 The internal module documentation is based on [jsdoc](http://usejsdoc.org) and
 can be generated with:
 

--- a/lib/counter.js
+++ b/lib/counter.js
@@ -38,8 +38,6 @@ const defaults = {
   expiration: defaultExpiration
 };
 
-const momentFormat = 'YYYYMMDDHHmmss';
-
 /**
  * Convert the given granularity level into the internal representation (a
  * number).
@@ -97,35 +95,31 @@ const createRangeParser = keyRange =>
 const createRangeTotalParser = () =>
   results => _.sum(utils.parseIntArray(results));
 
-const incrSingle = (client, key, amount, eventObj, ttl, cb) => {
+const incrSingle = (client, key, amount, eventObj, ttl) => {
   if (eventObj) {
     key += ':z';
 
     if (ttl > 0) {
-      if (cb) client.eval(lua.zincrbyExpire, 1, key, amount, eventObj, ttl, cb);
-      else client.eval(lua.zincrbyExpire, 1, key, amount, eventObj, ttl);
-    } else if (cb) {
-      client.zincrby(key, amount, eventObj, cb);
-    } else {
-      client.zincrby(key, amount, eventObj);
+      return utils.ninvoke(client, 'eval', lua.zincrbyExpire, 1, key, amount, eventObj, ttl);
     }
-  } else if (ttl > 0) { // No event object
-    if (cb) client.eval(lua.incrbyExpire, 1, key, amount, ttl, cb);
-    else client.eval(lua.incrbyExpire, 1, key, amount, ttl);
-  } else if (cb) {
-    client.incrby(key, amount, cb);
-  } else {
-    client.incrby(key, amount);
+
+    return utils.ninvoke(client, 'zincrby', key, amount, eventObj);
   }
+
+  if (ttl > 0) { // No event object
+    return utils.ninvoke(client, 'eval', lua.incrbyExpire, 1, key, amount, ttl);
+  }
+
+  return utils.ninvoke(client, 'incrby', key, amount);
 };
 
-const zero = (client, key, eventObj, cb) => {
+const zero = (client, key, eventObj) => {
   if (eventObj) {
     key += ':z';
-    client.zrem(key, eventObj, cb);
-  } else {
-    client.del(key, cb);
+    return utils.ninvoke(client, 'zrem', key, eventObj);
   }
+
+  return utils.ninvoke(client, 'del', key);
 };
 
 /**
@@ -135,17 +129,10 @@ const zero = (client, key, eventObj, cb) => {
  * @private
  */
 const rankParser = rank => {
-  // groups the array for each second row
-  rank = _.groupBy(rank, (row, index) => Math.floor(index / 2));
-
-  // transform the object into an array
-  // and the values to integer
-  return _.toArray(rank)
-    .map(row => {
-      const _row = {};
-      _row[row[0]] = parseInt(row[1], 10);
-      return _row;
-    });
+  return _.chain(rank)
+    .chunk(2)
+    .map(([key, count]) => ({ [key]: Number(count) }))
+    .value();
 };
 
 const createRankRangeParser = keyRange =>
@@ -163,7 +150,7 @@ const createRankTotalParser = (direction, startingAt, limit) => ranks => {
     .reduce((acc, [key, count]) => _.tap(acc, acc => {
       acc[key] = (acc[key] || 0) + Number(count);
     }), { })
-    .pairs()
+    .toPairs()
     .sortBy(([, count]) => direction === 'asc' ? count : -count)
     .drop(startingAt)
     .takeWhile((value, index) => limit <= 0 || index < limit)
@@ -176,30 +163,56 @@ const createRankTotalParser = (direction, startingAt, limit) => ranks => {
  * requested for the final result - and as a query granularity - that which will
  * be used to generate the query timestamps.
  *
- * @param  {String} timeGranularity The requested granularity for the result.
+ * @param  {String} timeGranularity               The requested granularity for the result.
+ * @param  {Number} defaultCounterTimeGranularity The counter's default granularity.
  * @return {Object}                 An object { reportTimeGranularity, rangeTimeGranularity }
  */
-const parseRangeTimeGranularities = (timeGranularity, counterGranularity) => {
-  timeGranularity = parseTimeGranularity(timeGranularity);
-
-  // Save the report time granularity because it might change for the query.
-  const reportTimeGranularity = timeGranularity;
+const parseRangeTimeGranularities = (timeGranularity, defaultCounterTimeGranularity) => {
+  const reportTimeGranularity = parseTimeGranularity(timeGranularity);
+  let rangeTimeGranularity = reportTimeGranularity;
 
   // If the range granularity is total, fall back to the granularity specified
   // at the counter level and then add the numbers together when parsing the
   // result.
-  if (timeGranularity === timeGranularities.total) {
-    timeGranularity = counterGranularity;
+  if (rangeTimeGranularity === timeGranularities.total) {
+    rangeTimeGranularity = defaultCounterTimeGranularity;
 
-    // If the rangeGranularity is still total, it does not make sense to report
+    // If the rangeTimeGranularity is still total, it does not make sense to report
     // a range for the counter and we throw an error.
-    if (timeGranularity === timeGranularities.total) {
+    if (rangeTimeGranularity === timeGranularities.total) {
       throw new Error('total granularity not supported for this counter');
     }
   }
 
-  return { reportTimeGranularity, rangeTimeGranularity: timeGranularity };
+  return { reportTimeGranularity, rangeTimeGranularity };
 };
+
+/**
+ * Creates the range of keys to fetch from Redis as well as the keys to use in
+ * the returned data object.
+ *
+ * Implementation notes:
+ * `_.over` calls all functions in the array with each element in an array. This
+ * means both key arrays are generated in one pass of the `momentRange`. Then,
+ * `_.wrap` just converts the two-element array return into an object.
+ *
+ * @param  {moment[]} momentRange     An array of moment objects for mapping
+ *                                    into redis keys and times.
+ * @param  {String}   key             The base redis key.
+ * @param  {Number}   timeGranularity The time granularity for the moments.
+ * @return {Object}                   Both ranges in an object as `keyRange` and
+ *                                    `momentKeyRange`.
+ */
+const keyAndMomentRange = _.wrap(
+  _.over([
+    utils.momentToKeyRange,
+    momentRange => momentRange.map(m => m.format())
+  ]),
+  (func, ...args) => {
+    const [keyRange, momentKeyRange] = func(...args);
+    return { keyRange, momentKeyRange };
+  }
+);
 
 /**
  * A timestamped event counter.
@@ -224,8 +237,8 @@ const parseRangeTimeGranularities = (timeGranularity, counterGranularity) => {
  * @class
  */
 class TimestampedCounter {
-  constructor(metrics, key, options) {
-    this.options = options || {};
+  constructor(metrics, key, options = {}) {
+    this.options = options;
     _.defaults(this.options, _.cloneDeep(defaults));
 
     this.metrics = metrics;
@@ -254,7 +267,7 @@ class TimestampedCounter {
   getKeys(time, timeGranularity) {
     return getKeys(
       this.key,
-      (time || moment.utc()).format(momentFormat),
+      (time || moment.utc()).format(utils.REDIS_MOMENT_FORMAT),
       parseTimeGranularity(timeGranularity) || this.options.timeGranularity
     );
   }
@@ -298,59 +311,52 @@ class TimestampedCounter {
   /**
    * Increments this counter with 1.
    *
-   * For some use cases, it makes sense to pass in an event object to get more
-   * precise statistics for a specific event. For example, when counting page
-   * views on a page, it makes sense to increment a counter per specific page.
-   * For this use case, the eventObj parameter is a good fit.
-   *
-   * @param {Object|string} [eventObj] - Extra event information used to
-   *   determine what counter to increment.
-   * @param {function} [callback] - Optional callback.
-   * @returns {Promise} A promise that resolves to the results from Redis. Can
-   *   be used instead of the callback function.
-   * @since 0.1.0
+   * @param   {Object}  [opts] @see `#incrby`
+   * @returns {Promise}        A promise that resolves to the results from Redis.
+   * @since 2.0.0
    */
-  incr(eventObj, callback) {
-    return this.incrby(1, eventObj, callback);
+  incr(opts = {}) {
+    return this.incrby(1, opts);
   }
 
   /**
    * Increments this counter with the given amount.
    *
-   * @param {number} amount - The amount to increment with.
-   * @param {Object|string} [eventObj] - Extra event information used to
-   *   determine what counter to increment. See {@link TimestampedCounter#incr}.
-   * @param {function} [callback] - Optional callback.
-   * @returns {Promise} A promise that resolves to the results from Redis. Can
-   *   be used instead of the callback function.
-   * @see {@link TimestampedCounter#incr}
-   * @since 0.2.0
+   * For some use cases, it makes sense to pass in an event object to get more
+   * precise statistics for a specific event. For example, when counting page
+   * views on a page, it makes sense to increment a counter per specific page.
+   * For this use case, the eventObj parameter is a good fit.
+   *
+   * @param {number}        amount           The amount to increment with.
+   * @param {Object}        [opts]           Optional config for this call.
+   * @param {Object|string} [opts.eventObj]  Extra event information to
+   *                                         determine which counter total
+   *                                         increment.
+   * @returns {Promise}                      A promise that resolves to the
+   *                                         results from Redis.
+   * @since 2.0.0
    */
-  incrby(amount, eventObj, callback) {
-    // The event object is optional so it might be a callback.
-    if (_.isFunction(eventObj)) {
-      callback = eventObj;
-      eventObj = null;
-    }
+  incrby(amount, { eventObj = null } = {}) {
     if (eventObj) eventObj = String(eventObj);
-    const deferred = utils.defer();
-    const cb = utils.createRedisCallback(deferred, callback);
-    this._incrby(amount, eventObj, cb);
-    return deferred.promise;
-  }
 
-  _incrby(amount, eventObj, cb) {
     const keys = this.getKeys();
+
     // Optimize for the case where there is only a single key to increment.
     if (keys.length === 1) {
-      incrSingle(this.metrics.client, keys[0], amount, eventObj, this.getKeyTTL(keys[0]), cb);
-    } else {
-      const multi = this.metrics.client.multi();
-      keys.forEach(key => {
-        incrSingle(multi, key, amount, eventObj, this.getKeyTTL(key));
-      });
-      multi.exec(cb);
+      return incrSingle(
+        this.metrics.client,
+        keys[0],
+        amount,
+        eventObj,
+        this.getKeyTTL(keys[0])
+      );
     }
+
+    const multi = this.metrics.client.multi();
+    keys.forEach(key => {
+      incrSingle(multi, key, amount, eventObj, this.getKeyTTL(key));
+    });
+    return utils.ninvoke(multi, 'exec');
   }
 
   /**
@@ -364,15 +370,15 @@ class TimestampedCounter {
    * not incremented at this granularity level in the first place.
    *
    * @example
-   * myCounter.count((err, result) => {
+   * myCounter.count().then(result => {
    *   console.log(result); // Outputs the global count
    * });
    * @example
-   * myCounter.count('year', (err, result) => {
+   * myCounter.count({ granularity: 'year' }).then(result => {
    *   console.log(result); // Outputs the count for the current year
    * });
    * @example
-   * myCounter.count('year', '/foo.html', (err, result) => {
+   * myCounter.count({ granularity: 'year', eventObj: '/foo.html' }).then(result => {
    *   // Outputs the count for the current year for the event object '/foo.html'
    *   console.log(result);
    * });
@@ -381,46 +387,30 @@ class TimestampedCounter {
    *   granularity level to report the count for.
    * @param {string|object} [eventObj] - The event object. See
    *   {@link TimestampedCounter#incr} for more info on event objects.
-   * @param {function} [callback] - Optional callback.
-   * @returns {Promise} A promise that resolves to the result from Redis. Can
-   *   be used instead of the callback function.
+   * @returns {Promise} A promise that resolves to the result from Redis
    * @since 0.1.0
    */
-  count(timeGranularity, eventObj, callback) {
-    const args = Array.prototype.slice.call(arguments);
-
-    // Last argument is callback;
-    callback = typeof args[args.length - 1] === 'function' ? args.pop() : null;
-
-    // Event object requires that the time granularity is specified, otherwise we
-    // can't reliably distinguish between them because both the eventObj and time
-    // granularity can be strings. I miss Python.
-    eventObj = args.length > 1 ? args.pop() : null;
-
-    // Still any arguments left? That's a time granularity.
-    timeGranularity = args.length > 0 ? args.pop() : 'none';
+  count({ timeGranularity = 'total', eventObj = null } = {}) {
     timeGranularity = parseTimeGranularity(timeGranularity);
 
-    const deferred = utils.defer();
-    const cb = utils.createRedisCallback(deferred, callback, utils.parseInt);
-    this._count(timeGranularity, eventObj, cb);
-    return deferred.promise;
-  }
+    const key = this.getKeys()[timeGranularity];
+    let resultPromise;
 
-  _count(timeGranularity, eventObj, cb) {
-    const theKey = this.getKeys()[timeGranularity];
     if (eventObj) {
-      this.metrics.client.zscore(theKey + ':z', eventObj, cb);
+      resultPromise = utils.ninvoke(this.metrics.client, 'zscore', `${key}:z`, eventObj);
     } else {
-      this.metrics.client.get(theKey, cb);
+      resultPromise = utils.ninvoke(this.metrics.client, 'get', key);
     }
+
+    return resultPromise.then(utils.parseInt);
   }
 
   /**
    * Returns an object mapping timestamps to counts in the given time range at a
    * specific time granularity level.
    *
-   * Notice: This function does not make sense for the "none" time granularity.
+   * Notice: This function does not make sense for the "none"  or "total" time
+   * granularities, and will throw an error accordingly.
    *
    * @param {module:constants~timeGranularities} timeGranularity - The
    *   granularity level to report the count for.
@@ -432,61 +422,48 @@ class TimestampedCounter {
    *   {@link http://momentjs.com/|moment} date.
    * @param {string|object} [eventObj] - The event object. See
    *   {@link TimestampedCounter#incr} for more info on event objects.
-   * @param {function} [callback] - Optional callback.
-   * @returns {Promise} A promise that resolves to the result from Redis. Can
-   *   be used instead of the callback function.
+   * @returns {Promise} A promise that resolves to the result from Redis.
    * @since 0.1.0
    */
-  countRange(timeGranularity, startDate, endDate, eventObj, callback) {
-    if (_.isFunction(eventObj)) {
-      callback = eventObj;
-      eventObj = null;
-    } else if (_.isFunction(endDate)) {
-      callback = endDate;
-      endDate = moment.utc();
-    } else {
-      endDate = endDate || moment.utc();
-    }
+  countRange(timeGranularity, { startDate, endDate = moment.utc() }, { eventObj = null } = {}) {
     if (eventObj) eventObj = String(eventObj);
 
-    const {
-      reportTimeGranularity,
+    let reportTimeGranularity;
+    let rangeTimeGranularity;
+    let momentRange;
+
+    try {
+      ({
+        reportTimeGranularity,
+        rangeTimeGranularity
+      } = parseRangeTimeGranularities(timeGranularity, this.options.timeGranularity));
+
+      momentRange = utils.momentRange(startDate, endDate, rangeTimeGranularity);
+    } catch (err) {
+      return Promise.reject(err);
+    }
+
+    const { keyRange, momentKeyRange } = keyAndMomentRange(
+      momentRange,
+      this.key,
       rangeTimeGranularity
-    } = parseRangeTimeGranularities(timeGranularity, this.options.timeGranularity);
+    );
 
-    const momentRange = utils.momentRange(startDate, endDate, rangeTimeGranularity);
-    const keyRange = [];
-    const momentKeyRange = [];
+    const parser = reportTimeGranularity === timeGranularities.total
+      ? createRangeTotalParser()
+      : createRangeParser(momentKeyRange);
 
-    // Create the range of keys to fetch from Redis as well as the keys to use in
-    // the returned data object.
-    momentRange.forEach(m => {
-      // Redis key range
-      const mKeyFormat = m.format(momentFormat).slice(0, (rangeTimeGranularity * 2) + 2);
-      keyRange.push(`${this.key}:${mKeyFormat}`);
+    let resultPromise;
 
-      // Timestamp range. Use ISO format for easy parsing back to a timestamp.
-      momentKeyRange.push(m.format());
-    });
-
-    const deferred = utils.defer();
-    const parser = reportTimeGranularity === timeGranularities.total ?
-      createRangeTotalParser() : createRangeParser(momentKeyRange);
-    const cb = utils.createRedisCallback(deferred, callback, parser);
-
-    this._countRange(keyRange, eventObj, cb);
-
-    return deferred.promise;
-  }
-
-  _countRange(keys, eventObj, cb) {
     if (eventObj) {
       const multi = this.metrics.client.multi();
-      keys.forEach(key => multi.zscore(key + ':z', eventObj));
-      multi.exec(cb);
+      keyRange.forEach(key => multi.zscore(key + ':z', eventObj));
+      resultPromise = utils.ninvoke(multi, 'exec');
     } else {
-      this.metrics.client.mget(keys, cb);
+      resultPromise = utils.ninvoke(this.metrics.client, 'mget', keyRange);
     }
+
+    return resultPromise.then(parser);
   }
 
   /**
@@ -498,11 +475,11 @@ class TimestampedCounter {
    * answer to questions such as "what is the rank for the current day".
    *
    * @example
-   * myCounter.top((err, result) => {
+   * myCounter.top().then(result => {
    *   console.log(result); // Outputs the global rank
    * });
    * @example
-   * myCounter.top('year', (err, result) => {
+   * myCounter.top({ timeGranularity: 'year' }).then(result => {
    *   console.log(result); // Outputs the rank for the current year
    * });
    *
@@ -511,56 +488,31 @@ class TimestampedCounter {
    * @param {string} [direction=desc] - Optional sort direction, can be "asc" or "desc"
    * @param {integer} [startingAt=0] - Optional starting row.
    * @param {integer} [limit=-1] - Optional number of results to return.
-   * @param {function} [callback] - Optional callback.
-   * @returns {Promise} A promise that resolves to the result from Redis. Can
-   *   be used instead of the callback function.
-   * @since 0.1.1
+   * @returns {Promise} A promise that resolves to the result from Redis.
+   * @since 2.0.0
    */
-  top(timeGranularity, direction, startingAt, limit, callback) {
-    const args = Array.prototype.slice.call(arguments);
-
-    // Last argument is callback;
-    callback = typeof args[args.length - 1] === 'function' ? args.pop() : null;
-
-    limit = args.length > 3 ? args.pop() : -1;
-    startingAt = args.length > 2 ? args.pop() : 0;
-    direction = args.length > 1 ? args.pop() : 'desc';
-
+  top({ timeGranularity = 'total', direction = 'desc', startingAt = 0, limit = -1 } = {}) {
     if (['asc', 'desc'].indexOf(direction) === -1) {
-      throw new Error(
-        'The direction parameter is expected to be one between ' +
+      return Promise.reject(new Error(
+        'The direction option is expected to be one of ' +
         '"asc" or "desc", got "' + direction + '".'
-      );
+      ));
     }
 
     timeGranularity = parseTimeGranularity(timeGranularity);
 
-    const deferred = utils.defer();
-    const cb = utils.createRedisCallback(deferred, callback, rankParser);
-    this._top(timeGranularity, direction, startingAt, limit, cb);
-    return deferred.promise;
-  }
+    const key = this.getKeys()[timeGranularity];
+    const redisFn = direction === 'asc' ? 'zrange' : 'zrevrange';
 
-  _top(timeGranularity, direction, startingAt, limit, cb) {
-    const theKey = this.getKeys()[timeGranularity];
-
-    if (direction === 'asc') {
-      return this.metrics.client.zrange(
-        theKey + ':z',
-        startingAt,
-        limit,
-        'WITHSCORES',
-        cb
-      );
-    }
-
-    this.metrics.client.zrevrange(
-      theKey + ':z',
+    return utils.ninvoke(
+      this.metrics.client,
+      redisFn,
+      key + ':z',
       startingAt,
       limit,
-      'WITHSCORES',
-      cb
-    );
+      'WITHSCORES'
+    )
+    .then(rankParser);
   }
 
   /**
@@ -584,91 +536,69 @@ class TimestampedCounter {
    * @param {string} [direction=desc] - Optional sort direction, can be "asc" or "desc"
    * @param {integer} [startingAt=0] - Optional starting row.
    * @param {integer} [limit=-1] - Optional number of results to return.
-   * @param {function} [callback] - Optional callback.
-   * @returns {Promise} A promise that resolves to the result from Redis. Can
-   *   be used instead of the callback function.
-   * @since 1.3.0
+   * @returns {Promise} A promise that resolves to the result from Redis.
+   * @since 2.0.0
    */
-  topRange(startDate, endDate, timeGranularity, direction, startingAt, limit, callback) {
-    const args = Array.prototype.slice.call(arguments);
-
-    // Last argument is callback;
-    callback = typeof args[args.length - 1] === 'function' ? args.pop() : null;
-
-    limit = args.length > 5 ? args.pop() : -1;
-    startingAt = args.length > 4 ? args.pop() : 0;
-    direction = args.length > 3 ? args.pop() : 'desc';
-    if (args.length > 2) args.pop(); // default handled in parseTimeGranularity;
-    endDate = args.length > 1 ? args.pop() : moment.utc();
-
-    if (!startDate) {
-      throw new Error('The startDate parameter is required.');
-    }
-
+  topRange(
+    { startDate, endDate = moment.utc() },
+    {
+      timeGranularity = 'total',
+      direction = 'desc',
+      startingAt = 0,
+      limit = -1
+    } = {}
+  ) {
     if (['asc', 'desc'].indexOf(direction) === -1) {
-      throw new Error(
-        'The direction parameter is expected to be one between ' +
+      return Promise.reject(new Error(
+        'The direction option is expected to be one between ' +
         '"asc" or "desc", got "' + direction + '".'
-      );
+      ));
     }
 
-    const {
-      reportTimeGranularity,
+    let reportTimeGranularity;
+    let rangeTimeGranularity;
+    let momentRange;
+
+    try {
+      ({
+        reportTimeGranularity,
+        rangeTimeGranularity
+      } = parseRangeTimeGranularities(timeGranularity, this.options.timeGranularity));
+
+      momentRange = utils.momentRange(startDate, endDate, rangeTimeGranularity);
+    } catch (err) {
+      return Promise.reject(err);
+    }
+
+    const { keyRange, momentKeyRange } = keyAndMomentRange(
+      momentRange,
+      this.key,
       rangeTimeGranularity
-    } = parseRangeTimeGranularities(timeGranularity, this.options.timeGranularity);
+    );
 
-    const momentRange = utils.momentRange(startDate, endDate, rangeTimeGranularity);
-    const keyRange = [];
-    const momentKeyRange = [];
-
-    // Create the range of keys to fetch from Redis as well as the keys to use in
-    // the returned data object.
-    momentRange.forEach(m => {
-      // Redis key range
-      const mKeyFormat = m.format(momentFormat).slice(0, (rangeTimeGranularity * 2) + 2);
-      keyRange.push(`${this.key}:${mKeyFormat}`);
-
-      // Timestamp range. Use ISO format for easy parsing back to a timestamp.
-      momentKeyRange.push(m.format());
-    });
-
-    const deferred = utils.defer();
+    const multi = this.metrics.client.multi();
+    let parser;
 
     if (reportTimeGranularity === timeGranularities.total) {
-      const cb = utils.createRedisCallback(
-        deferred,
-        callback,
-        createRankTotalParser(direction, startingAt, limit)
-      );
+      parser = createRankTotalParser(direction, startingAt, limit);
 
-      this._topRange(keyRange, 'asc', 0, -1, cb); // get everything and re-count on parser
+      // we need to get every value so that we can re-aggregate in the parser
+      keyRange.forEach(key => multi.zrange(key + ':z', 0, -1, 'WITHSCORES'));
     } else {
-      const cb = utils.createRedisCallback(
-        deferred,
-        callback,
-        createRankRangeParser(momentKeyRange)
-      );
+      parser = createRankRangeParser(momentKeyRange);
 
-      this._topRange(keyRange, direction, startingAt, limit, cb);
-    }
-
-    return deferred.promise;
-  }
-
-  _topRange(keys, direction, startingAt, limit, cb) {
-    const multi = this.metrics.client.multi();
-
-    keys.forEach(key => {
       const redisFn = direction === 'asc' ? 'zrange' : 'zrevrange';
-      multi[redisFn](
+
+      keyRange.forEach(key => multi[redisFn](
         key + ':z',
         startingAt,
         limit,
         'WITHSCORES'
-      );
-    });
+      ));
+    }
 
-    multi.exec(cb);
+    return utils.ninvoke(multi, 'exec')
+      .then(parser);
   }
 
   /**
@@ -689,10 +619,9 @@ class TimestampedCounter {
    * Therefore, the function should only be used to try and reclaim space for
    * big counters with a lot of event objects, and only rarely used.
    *
-   * @param {string} [keepDirection=desc] - Sort direction for the top-N
+   * @param {string} [direction=desc] - Sort direction for the top-N
    * elements to keep, can be "asc" or "desc".
    * @param {integer} [limit=1000] - Number of results to keep.
-   * @param {function} [callback] - Callback
    * @returns {Promise} Resolves when the values have been removed.
    * @example
    * // Keeps the top-5 elements with highest score
@@ -700,33 +629,26 @@ class TimestampedCounter {
    * @example
    * // Keeps the top-5 elements with lowest score
    * myCounter.trimEvents('asc', 5)
-   * @since 1.1.0
+   * @since 2.0.0
    */
-  trimEvents(keepDirection, limit, callback) {
-    const args = Array.prototype.slice.call(arguments);
-    callback = typeof args[args.length - 1] === 'function' ? args.pop() : null;
-    limit = args.length > 1 ? args.pop() : 1000;
-    keepDirection = args.length > 0 ? args.pop() : 'desc';
-
-    if (['asc', 'desc'].indexOf(keepDirection) === -1) {
-      throw new Error(
-        'The keepDirection parameter is expected to be one between ' +
-        '"asc" or "desc", got "' + keepDirection + '".'
-      );
+  trimEvents({ direction = 'desc', limit = 1000 } = {}) {
+    if (['asc', 'desc'].indexOf(direction) === -1) {
+      return Promise.reject(new Error(
+        'The direction parameter is expected to be one between ' +
+        '"asc" or "desc", got "' + direction + '".'
+      ));
     }
 
     // If we want to keep top-5 lowest scores, remove rank 5 to -1
     // If we want to keep top-5 highest scores, remove rank 0 to -(5 + 1)
-    const startIndex = keepDirection === 'asc' ? limit : 0;
-    const endIndex = keepDirection === 'asc' ? -1 : -(limit + 1);
-
-    const deferred = utils.defer();
-    const cb = utils.createRedisCallback(deferred, callback);
+    const startIndex = direction === 'asc' ? limit : 0;
+    const endIndex = direction === 'asc' ? -1 : -(limit + 1);
 
     // If the counter does not have a time granularity, our job is easy.
     if (this.options.timeGranularity === timeGranularities.none) {
-      this.metrics.client.zremrangebyrank(`${this.key}:z`, startIndex, endIndex, cb);
-      return deferred.promise;
+      return utils.ninvoke(
+        this.metrics.client, 'zremrangebyrank', `${this.key}:z`, startIndex, endIndex
+      );
     }
 
     // Otherwise trim keys for the last five years.
@@ -745,22 +667,19 @@ class TimestampedCounter {
 
     // Each key is mapped to a function that returns a Promise.
     const mappedPromiseFunctions = Array.from(keySet).map(key => {
-      return () => {
-        const subDeferred = utils.defer();
-        const subCallback = utils.createRedisCallback(subDeferred);
-        this.metrics.client.zremrangebyrank(`${key}:z`, startIndex, endIndex, subCallback);
-        return subDeferred.promise;
-      };
+      return () => utils.ninvoke(
+        this.metrics.client,
+        'zremrangebyrank',
+        `${key}:z`,
+        startIndex,
+        endIndex
+      );
     });
 
     // Each function is executed sequentially using reduce.
-    mappedPromiseFunctions.reduce((promise, f) => {
+    return mappedPromiseFunctions.reduce((promise, f) => {
       return promise.then(totalRemoved => f().then(removed => totalRemoved + removed));
-    }, Promise.resolve(0))
-    .then(totalRemoved => cb(null, totalRemoved))
-    .catch(err => cb(err));
-
-    return deferred.promise;
+    }, Promise.resolve(0));
   }
 
   /**
@@ -772,11 +691,7 @@ class TimestampedCounter {
    * @param  {Function}       [callback] Optional callback.
    * @return {Promise}                   Resolves when done.
    */
-  zero(eventObj, callback) {
-    if (_.isFunction(eventObj)) {
-      callback = eventObj;
-      eventObj = null;
-    }
+  zero({ eventObj = null } = {}) {
     if (eventObj) eventObj = String(eventObj);
 
     const keySet = new Set();
@@ -795,25 +710,13 @@ class TimestampedCounter {
         .forEach(addKeys);
     }
 
-    const deferred = utils.defer();
-    const cb = utils.createRedisCallback(deferred, callback);
-
     const mappedPromiseFunctions = Array.from(keySet).map(key => {
-      return () => {
-        const subDeferred = utils.defer();
-        const subCallback = utils.createRedisCallback(subDeferred);
-        zero(this.metrics.client, key, eventObj, subCallback);
-        return subDeferred.promise;
-      };
+      return () => zero(this.metrics.client, key, eventObj);
     });
 
-    mappedPromiseFunctions.reduce((promise, f) => {
+    return mappedPromiseFunctions.reduce((promise, f) => {
       return promise.then(() => f());
-    }, Promise.resolve())
-    .then(() => cb())
-    .catch(err => cb(err));
-
-    return deferred.promise;
+    }, Promise.resolve());
   }
 }
 

--- a/lib/counter.js
+++ b/lib/counter.js
@@ -2,7 +2,7 @@
 
 const _ = require('lodash'),
   moment = require('moment'),
-  timeGranularities = require('./constants').timeGranularities,
+  { timeGranularities } = require('./constants'),
   utils = require('./utils'),
   lua = require('./lua');
 
@@ -14,11 +14,11 @@ const _ = require('lodash'),
 const defaultExpiration = {
   total: -1,
   year: -1,
-  month:  10 * 365 * 24 * 60 * 60, // 10 years = 120 counters worst-case
-  day:  2 * 365 * 24 * 60 * 60,    // 2 years = 730 counters worst-case
-  hour:  31 * 24 * 60 * 60,        // 31 days = 744 counters worst-case
-  minute:  12 * 60 * 60,           // 12 hours = 720 counters worst-case
-  second:  10 * 60                 // 10 minutes = 600 counters worst-case
+  month: 10 * 365 * 24 * 60 * 60, // 10 years = 120 counters worst-case
+  day: 2 * 365 * 24 * 60 * 60,    // 2 years = 730 counters worst-case
+  hour: 31 * 24 * 60 * 60,        // 31 days = 744 counters worst-case
+  minute: 12 * 60 * 60,           // 12 hours = 720 counters worst-case
+  second: 10 * 60                 // 10 minutes = 600 counters worst-case
 };
 // BTW, good luck keeping your Redis server around for 10 years :-)
 
@@ -49,7 +49,7 @@ const momentFormat = 'YYYYMMDDHHmmss';
 const parseTimeGranularity = timeGranularity => {
   timeGranularity = timeGranularities[timeGranularity];
   if (timeGranularity) return timeGranularity;
-  else return timeGranularities.none;
+  return timeGranularities.none;
 };
 
 /**
@@ -73,7 +73,7 @@ const getKeys = (baseKey, formattedTimestamp, timeGranularity) => {
   }
 
   for (let i = 1; i <= timeGranularity; i++) {
-    keys.push(`${baseKey}:${formattedTimestamp.slice(0, i * 2 + 2)}`);
+    keys.push(`${baseKey}:${formattedTimestamp.slice(0, (i * 2) + 2)}`);
   }
 
   return keys;
@@ -104,20 +104,18 @@ const incrSingle = (client, key, amount, eventObj, ttl, cb) => {
     if (ttl > 0) {
       if (cb) client.eval(lua.zincrbyExpire, 1, key, amount, eventObj, ttl, cb);
       else client.eval(lua.zincrbyExpire, 1, key, amount, eventObj, ttl);
+    } else if (cb) {
+      client.zincrby(key, amount, eventObj, cb);
     } else {
-      if (cb) client.zincrby(key, amount, eventObj, cb);
-      else client.zincrby(key, amount, eventObj);
+      client.zincrby(key, amount, eventObj);
     }
-
-  } else { // No event object
-
-    if (ttl > 0) {
-      if (cb) client.eval(lua.incrbyExpire, 1, key, amount, ttl, cb);
-      else client.eval(lua.incrbyExpire, 1, key, amount, ttl);
-    } else {
-      if (cb) client.incrby(key, amount, cb);
-      else client.incrby(key, amount);
-    }
+  } else if (ttl > 0) { // No event object
+    if (cb) client.eval(lua.incrbyExpire, 1, key, amount, ttl, cb);
+    else client.eval(lua.incrbyExpire, 1, key, amount, ttl);
+  } else if (cb) {
+    client.incrby(key, amount, cb);
+  } else {
+    client.incrby(key, amount);
   }
 };
 
@@ -159,23 +157,17 @@ const createRankRangeParser = keyRange =>
  * @return {object}       In this format: [{ foo: 50 }, { bar: 13 }]
  */
 const createRankTotalParser = (direction, startingAt, limit) => ranks => {
-  // TODO-V4 destructure here
   return _.chain(ranks)
     .flatten()
     .chunk(2)
-    .reduce((acc, metric) => {
-      acc[metric[0]] = (acc[metric[0]] || 0) + parseInt(metric[1]);
-      return acc;
-    }, { })
+    .reduce((acc, [key, count]) => _.tap(acc, acc => {
+      acc[key] = (acc[key] || 0) + Number(count);
+    }), { })
     .pairs()
-    .sortBy(metric => direction === 'asc' ? metric[1] : -metric[1])
+    .sortBy(([, count]) => direction === 'asc' ? count : -count)
     .drop(startingAt)
     .takeWhile((value, index) => limit <= 0 || index < limit)
-    .map(metric => {
-      const obj = {};
-      obj[metric[0]] = metric[1];
-      return obj;
-    })
+    .map(([key, count]) => ({ [key]: count }))
     .value();
 };
 
@@ -457,10 +449,10 @@ class TimestampedCounter {
     }
     if (eventObj) eventObj = String(eventObj);
 
-    // TODO-V4 destructure here
-    const grans = parseRangeTimeGranularities(timeGranularity, this.options.timeGranularity);
-    const reportTimeGranularity = grans.reportTimeGranularity;
-    const rangeTimeGranularity = grans.rangeTimeGranularity;
+    const {
+      reportTimeGranularity,
+      rangeTimeGranularity
+    } = parseRangeTimeGranularities(timeGranularity, this.options.timeGranularity);
 
     const momentRange = utils.momentRange(startDate, endDate, rangeTimeGranularity);
     const keyRange = [];
@@ -470,7 +462,7 @@ class TimestampedCounter {
     // the returned data object.
     momentRange.forEach(m => {
       // Redis key range
-      const mKeyFormat = m.format(momentFormat).slice(0, rangeTimeGranularity * 2 + 2);
+      const mKeyFormat = m.format(momentFormat).slice(0, (rangeTimeGranularity * 2) + 2);
       keyRange.push(`${this.key}:${mKeyFormat}`);
 
       // Timestamp range. Use ISO format for easy parsing back to a timestamp.
@@ -620,10 +612,10 @@ class TimestampedCounter {
       );
     }
 
-    // TODO-V4 destructure here
-    const grans = parseRangeTimeGranularities(timeGranularity, this.options.timeGranularity);
-    const reportTimeGranularity = grans.reportTimeGranularity;
-    const rangeTimeGranularity = grans.rangeTimeGranularity;
+    const {
+      reportTimeGranularity,
+      rangeTimeGranularity
+    } = parseRangeTimeGranularities(timeGranularity, this.options.timeGranularity);
 
     const momentRange = utils.momentRange(startDate, endDate, rangeTimeGranularity);
     const keyRange = [];
@@ -633,7 +625,7 @@ class TimestampedCounter {
     // the returned data object.
     momentRange.forEach(m => {
       // Redis key range
-      const mKeyFormat = m.format(momentFormat).slice(0, rangeTimeGranularity * 2 + 2);
+      const mKeyFormat = m.format(momentFormat).slice(0, (rangeTimeGranularity * 2) + 2);
       keyRange.push(`${this.key}:${mKeyFormat}`);
 
       // Timestamp range. Use ISO format for easy parsing back to a timestamp.
@@ -744,9 +736,8 @@ class TimestampedCounter {
     const end = moment.utc();
     const keySet = new Set();
     while (currentTime.isBefore(end)) {
-      for (const key of this.getKeys(currentTime, timeGranularities.day)) {
-        keySet.add(key);
-      }
+      this.getKeys(currentTime, timeGranularities.day)
+        .forEach(key => keySet.add(key));
 
       // Mutates the time.
       currentTime.add(1, 'day');
@@ -790,9 +781,7 @@ class TimestampedCounter {
 
     const keySet = new Set();
     const end = moment.utc();
-    const addKeys = time => {
-      for (const key of this.getKeys(time)) keySet.add(key);
-    };
+    const addKeys = time => this.getKeys(time).forEach(key => keySet.add(key));
 
     // Get all keys with values for the 5-year range. We're limiting on the
     // expiration because 5 years of second granularity can easily blow up in

--- a/lib/lua.js
+++ b/lib/lua.js
@@ -5,9 +5,6 @@
  */
 
 module.exports = {
-  /* jslint maxlen: 500 */
-  /* jslint quotmark: false */
-  // jscs:disable maximumLineLength
   incrbyExpire: "local v = redis.call('INCRBY', KEYS[1], ARGV[1]) if tostring(v) == tostring(ARGV[1]) then redis.call('EXPIRE', KEYS[1], ARGV[2]) end return v",
   zincrbyExpire: "local v = redis.call('ZINCRBY', KEYS[1], ARGV[1], ARGV[2]) if tostring(v) == tostring(ARGV[1]) then redis.call('EXPIRE', KEYS[1], ARGV[3]) end return v"
 };

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -28,8 +28,8 @@ const redis = require('redis'),
  * @class
  */
 class RedisMetrics {
-  constructor(config) {
-    this.config = config = config || {};
+  constructor(config = {}) {
+    this.config = config;
 
     if (this.config.client) {
       this.client = this.config.client;
@@ -42,7 +42,7 @@ class RedisMetrics {
       /**
        * The client connection
        * @member {Object}
-       * **/
+       */
       this.client = redis.createClient();
     }
   }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -9,24 +9,7 @@ const _ = require('lodash'),
   moment = require('moment'),
   constants = require('./constants');
 
-/**
- * Creates a general callback for a redis client function that both resolves
- * the given promise as well as executing the callback function.
- * @param {Promise} deferred - A deferred promise object.
- * @param {function} [callback] - Optional callback to call.
- * @param {function} [resultParser] - Optional function for parsing the result.
- */
-const createRedisCallback = (deferred, callback, resultParser) => (err, result) => {
-  // (Maybe) parse the result.
-  if (typeof resultParser === 'function') result = resultParser(result);
-
-  // Handle the deferred.
-  if (err) deferred.reject(err);
-  else deferred.resolve(result);
-
-  // (Maybe call the callback)
-  if (typeof callback === 'function') callback(err, result);
-};
+const REDIS_MOMENT_FORMAT = 'YYYYMMDDHHmmss';
 
 /**
  * A simple parser that always returns an integer, no matter what value is
@@ -49,6 +32,8 @@ const parseIntSingle = i => {
 const parseIntArray = arrayOfInts => arrayOfInts.map(i => parseIntSingle(i));
 
 const momentRange = (startDate, endDate, timeGranularity) => {
+  if (!startDate) throw new TypeError('No startDate provided');
+
   timeGranularity = constants.timeGranularities[timeGranularity];
   startDate = moment.utc(startDate);
   endDate = moment.utc(endDate);
@@ -94,19 +79,60 @@ const momentRange = (startDate, endDate, timeGranularity) => {
   return timestamps;
 };
 
-const defer = () => {
-  const deferred = {};
-  deferred.promise = new Promise((resolve, reject) => {
-    deferred.resolve = resolve;
-    deferred.reject = reject;
+/**
+ * Converts a moment object array (returned from `momentRange`) into its
+ * corresponding redis keys.
+ *
+ * @param  {moment[]} momentRange     A range of moment objects.
+ * @param  {string}   baseKey         The base redis key, used to generate the
+ *                                    timestamped keys.
+ * @param  {number}   timeGranularity The granularity we're generating keys for.
+ * @return {string[]}                 The array of redis keys.
+ */
+const momentToKeyRange = (momentRange, baseKey, timeGranularity) => {
+  return momentRange.map(m => {
+    const mKeyFormat = m.format(REDIS_MOMENT_FORMAT).slice(0, (timeGranularity * 2) + 2);
+    return `${baseKey}:${mKeyFormat}`;
   });
-  return deferred;
+};
+
+/**
+ * Invoke a callback style function in a way such that it returns a promise
+ * and can thus be used in a promise-chain.
+ *
+ * @param {Object} moduleObject - A module object or simple object.
+ * @param {String} functionName - A function
+ *
+ * @example
+ *
+ * const promise = require('./lib/promise');
+ * const redis = require('./lib/services/redis');
+ * const { exec } = require('child_process')
+ *
+ * promise.ninvoke(redis, 'get', 'mykey').then(val => doSomething(val));
+ * promise.ninvoke(null, exec, 'mkdir tmp');
+ */
+const ninvoke = (moduleObject, functionName, ...args) => {
+  return new Promise((resolve, reject) => {
+    // Create a callback as the last argument for the function call.
+    args.push((err, res) => {
+      if (err) return reject(err);
+      resolve(res);
+    });
+
+    if (moduleObject === null) {
+      return functionName(...args);
+    }
+
+    moduleObject[functionName](...args);
+  });
 };
 
 module.exports = {
-  createRedisCallback,
+  REDIS_MOMENT_FORMAT,
   parseIntArray,
   momentRange,
-  defer,
+  momentToKeyRange,
+  ninvoke,
   parseInt: parseIntSingle
 };

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/metrics.js",
   "scripts": {
     "exectests": "node_modules/.bin/nyc ./node_modules/.bin/_mocha --exit",
-    "codecov": "node_modules/.bin/nyc ./node_modules/.bin/_mocha --exit && node_modules/.bin/nyc report --reporter=text-lcov > coverage.lcov && ./node_modules/.bin/codecov",
+    "codecov": "node_modules/.bin/nyc ./node_modules/.bin/_mocha --exit && node_modules/.bin/nyc report --reporter=text-lcov > coverage.lcov && codecov",
     "lint": "node_modules/.bin/eslint lib test --quiet",
     "test": "npm run exectests && npm run lint",
     "testci": "npm run lint && npm run codecov",

--- a/package.json
+++ b/package.json
@@ -1,14 +1,12 @@
 {
   "name": "redis-metrics",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "description": "Easy metric tracking and aggregation using Redis",
   "main": "lib/metrics.js",
   "scripts": {
-    "exectests": "node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha",
-    "codecov": "node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha --report lcovonly -- -R spec && codecov",
-    "jshint": "node_modules/.bin/jshint lib test",
-    "jscs": "node_modules/.bin/jscs lib test",
-    "lint": "npm run jshint && npm run jscs",
+    "exectests": "node_modules/.bin/nyc ./node_modules/.bin/_mocha --exit",
+    "codecov": "node_modules/.bin/nyc ./node_modules/.bin/_mocha --exit --report lcovonly -- -R spec && codecov",
+    "lint": "node_modules/.bin/eslint lib test --quiet",
     "test": "npm run exectests && npm run lint",
     "testci": "npm run lint && npm run codecov",
     "docs": "node_modules/.bin/jsdoc -c jsdoc.json"
@@ -30,18 +28,19 @@
   "license": "MIT",
   "dependencies": {
     "lodash": "^3.10.0",
-    "moment": "^2.11.1",
+    "moment": "^2.22.2",
     "redis": "^2.5.3"
   },
   "devDependencies": {
     "async": "^0.9.0",
     "chai": "^4.1.1",
+    "eslint": "^5.2.0",
+    "eslint-config-conversio": "^2.2.0",
+    "eslint-plugin-mocha": "^5.1.0",
     "ioredis": "^2.5.0",
-    "istanbul": "^0.3.13",
-    "jscs": "^2.11.0",
     "jsdoc": "^3.4.3",
-    "jshint": "^2.7.0",
-    "mocha": "^3.5.0",
-    "sinon": "^1.14.1"
+    "mocha": "^5.2.0",
+    "nyc": "^12.0.2",
+    "sinon": "^6.1.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/metrics.js",
   "scripts": {
     "exectests": "node_modules/.bin/nyc ./node_modules/.bin/_mocha --exit",
-    "codecov": "node_modules/.bin/nyc ./node_modules/.bin/_mocha --exit --report lcovonly -- -R spec && codecov",
+    "codecov": "node_modules/.bin/nyc ./node_modules/.bin/_mocha --exit && node_modules/.bin/nyc report --reporter=text-lcov > coverage.lcov && ./node_modules/.bin/codecov",
     "lint": "node_modules/.bin/eslint lib test --quiet",
     "test": "npm run exectests && npm run lint",
     "testci": "npm run lint && npm run codecov",
@@ -27,7 +27,7 @@
   "author": "Conversio <dev@conversio.com> (https://conversio.com)",
   "license": "MIT",
   "dependencies": {
-    "lodash": "^3.10.0",
+    "lodash": "^4.17.10",
     "moment": "^2.22.2",
     "redis": "^2.5.3"
   },

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,0 +1,12 @@
+{
+  "env": {
+    "mocha": true
+  },
+  "plugins": [
+    "mocha"
+  ],
+  "rules": {
+    "import/no-extraneous-dependencies": ["error", { "devDependencies": true }],
+    "mocha/no-exclusive-tests": "error"
+  }
+}

--- a/test/counter.js
+++ b/test/counter.js
@@ -4,6 +4,7 @@ const { expect } = require('chai'),
   sinon = require('sinon'),
   moment = require('moment'),
   IORedis = require('ioredis'),
+  { ensureError } = require('./utils'),
   RedisMetrics = require('../lib/metrics'),
   TimestampedCounter = require('../lib/counter'),
   constants = require('../lib/constants'),
@@ -323,25 +324,15 @@ describe('Counter', () => {
       });
     });
 
-    it('should call the callback on success', done => {
+    it('should resolve a promise on success', () => {
       const counter = new TimestampedCounter(metrics, 'foo');
-      counter.incr((err, result) => {
-        expect(err).to.equal(null);
+
+      return counter.incr().then(result => {
         expect(result).to.equal(1);
-        done();
       });
     });
 
-    it('should resolve a promise on success', done => {
-      const counter = new TimestampedCounter(metrics, 'foo');
-      counter.incr().then(result => {
-        expect(result).to.equal(1);
-        done();
-      })
-      .catch(done);
-    });
-
-    it('should call the callback on error', done => {
+    it('should reject on error', () => {
       sandbox.stub(metrics.client, 'incrby')
         .yields(new Error('oh no'), null);
 
@@ -350,56 +341,33 @@ describe('Counter', () => {
         'foo',
         { expireKeys: false }
       );
-      counter.incr((err, result) => {
-        expect(err).to.not.equal(null);
-        expect(result).to.equal(null);
-        done();
-      });
+
+      return ensureError(() => counter.incr());
     });
 
-    it('should reject the promise on error', done => {
-      sandbox.stub(metrics.client, 'incrby')
-        .yields(new Error('oh no'), null);
-
-      const counter = new TimestampedCounter(
-        metrics,
-        'foo',
-        { expireKeys: false }
-      );
-      counter.incr().then(() => {
-        done(new Error('Should not be here'));
-      })
-      .catch(err => {
-        expect(err).to.not.equal(null);
-        done();
-      });
-    });
-
-    it('should return a list of results', done => {
+    it('should return a list of results', () => {
       const counter = new TimestampedCounter(metrics, 'foo', {
         timeGranularity: 'year'
       });
 
-      counter.incr().then(results => {
-        expect(results).to.be.instanceof(Array);
-        expect(results).to.deep.equal([1, 1]);
-        done();
-      })
-      .catch(done);
+      return counter.incr()
+        .then(results => {
+          expect(results).to.be.instanceof(Array);
+          expect(results).to.deep.equal([1, 1]);
+        });
     });
 
-    it('should return a list of results for non-expiring keys', done => {
+    it('should return a list of results for non-expiring keys', () => {
       const counter = new TimestampedCounter(metrics, 'foo', {
         timeGranularity: 'year',
         expireKeys: false
       });
 
-      counter.incr().then(results => {
-        expect(results).to.be.instanceof(Array);
-        expect(results).to.deep.equal([1, 1]);
-        done();
-      })
-      .catch(done);
+      return counter.incr()
+        .then(results => {
+          expect(results).to.be.instanceof(Array);
+          expect(results).to.deep.equal([1, 1]);
+        });
     });
   });
 
@@ -412,7 +380,7 @@ describe('Counter', () => {
         }
       });
 
-      return counter.incr('bar').then(result => {
+      return counter.incr({ eventObj: 'bar' }).then(result => {
         expect(Number(result)).to.equal(1);
       });
     });
@@ -424,7 +392,7 @@ describe('Counter', () => {
         { expireKeys: false }
       );
 
-      return counter.incr('bar').then(result => {
+      return counter.incr({ eventObj: 'bar' }).then(result => {
         expect(Number(result)).to.equal(1);
       });
     });
@@ -438,7 +406,7 @@ describe('Counter', () => {
         }
       });
 
-      return counter.incr('bar').then(results => {
+      return counter.incr({ eventObj: 'bar' }).then(results => {
         expect(utils.parseIntArray(results)).to.deep.equal([1, 1]);
       });
     });
@@ -449,14 +417,114 @@ describe('Counter', () => {
         expireKeys: false
       });
 
-      return counter.incr('bar').then(results => {
+      return counter.incr({ eventObj: 'bar' }).then(results => {
         expect(utils.parseIntArray(results)).to.deep.equal([1, 1]);
       });
     });
   });
 
+  describe('incr with expiration', () => {
+    it('should set a ttl for a key', () => {
+      const counter = new TimestampedCounter(metrics, 'foo', {
+        expireKeys: true,
+        expiration: {
+          total: 100
+        }
+      });
+
+      return counter.incr()
+        .then(() => {
+          const [key] = counter.getKeys();
+          return utils.ninvoke(metrics.client, 'ttl', key);
+        })
+        .then(ttl => {
+          expect(ttl).to.be.above(0);
+          expect(ttl).to.be.most(100);
+        });
+    });
+
+    it('should set a ttl for a key with event objects', () => {
+      const counter = new TimestampedCounter(metrics, 'foo', {
+        expireKeys: true,
+        expiration: {
+          total: 100
+        }
+      });
+
+      return counter.incr({ eventObj: 'bar' })
+        .then(() => {
+          const key = counter.getKeys()[0] + ':z';
+          return utils.ninvoke(metrics.client, 'ttl', key);
+        })
+        .then(ttl => {
+          expect(ttl).to.be.above(0);
+          expect(ttl).to.be.most(100);
+        });
+    });
+
+    it('should not renew the ttl on the second call', () => {
+      const counter = new TimestampedCounter(metrics, 'foo', {
+        expireKeys: true,
+        expiration: {
+          total: 100
+        }
+      });
+
+      let key;
+
+      return counter.incr()
+        .then(() => {
+          [key] = counter.getKeys();
+          return utils.ninvoke(metrics.client, 'ttl', key);
+        })
+        .then(ttl => new Promise((resolve, reject) => {
+          setTimeout(() => {
+            counter.incr()
+              .then(() => utils.ninvoke(metrics.client, 'ttl', key))
+              .then(ttl2 => {
+                // Expect that ttl has decreased.
+                expect(ttl2).to.be.below(ttl);
+                expect(ttl2).to.be.within(ttl - 2, ttl);
+                resolve();
+              })
+              .catch(reject);
+          }, 1100);
+        }));
+    });
+
+    it('should not renew the ttl on the second call for eventObj', () => {
+      const counter = new TimestampedCounter(metrics, 'foo', {
+        expireKeys: true,
+        expiration: {
+          total: 100
+        }
+      });
+
+      let key;
+
+      return counter.incr({ eventObj: 'bar' })
+        .then(() => {
+          key = counter.getKeys()[0] + ':z';
+          return utils.ninvoke(metrics.client, 'ttl', key);
+        })
+        .then(ttl => new Promise((resolve, reject) => {
+          setTimeout(() => {
+            counter.incr({ eventObj: 'bar' })
+              .then(() => utils.ninvoke(metrics.client, 'ttl', key))
+              .then(ttl2 => {
+                // Expect that ttl has decreased.
+                expect(ttl2).to.be.below(ttl);
+                expect(ttl2).to.be.within(ttl - 2, ttl);
+                resolve();
+              })
+              .catch(reject);
+          }, 1100);
+        }));
+    });
+  });
+
   describe('incrby', () => {
-    it('should call redis without a tran when keys do not exp', done => {
+    it('should call redis without a tran when keys do not exp', () => {
       const multiSpy = sandbox.spy(metrics.client, 'multi');
       const incrSpy = sandbox.spy(metrics.client, 'incrby');
 
@@ -465,15 +533,14 @@ describe('Counter', () => {
         'foo',
         { expireKeys: false }
       );
-      counter.incrby(2).then(() => {
+
+      return counter.incrby(2).then(() => {
         sinon.assert.calledOnce(incrSpy);
         sinon.assert.notCalled(multiSpy);
-        done();
-      })
-      .catch(done);
+      });
     });
 
-    it('should call redis without a trans when counters exp', done => {
+    it('should call redis without a trans when counters exp', () => {
       const multiSpy = sandbox.spy(metrics.client, 'multi');
       const evalSpy = sandbox.spy(metrics.client, 'eval');
 
@@ -483,47 +550,34 @@ describe('Counter', () => {
           total: 10
         }
       });
-      counter.incrby(2).then(() => {
+
+      return counter.incrby(2).then(() => {
         sinon.assert.calledOnce(evalSpy);
         sinon.assert.notCalled(multiSpy);
-        done();
-      })
-      .catch(done);
+      });
     });
 
-    it('should call redis when a time granularity is chosen', done => {
+    it('should call redis when a time granularity is chosen', () => {
       const multiSpy = sandbox.spy(metrics.client, 'multi');
 
       const counter = new TimestampedCounter(metrics, 'foo', {
         timeGranularity: 'year'
       });
 
-      counter.incrby(3).then(() => {
+      return counter.incrby(3).then(() => {
         sinon.assert.calledOnce(multiSpy);
-        done();
-      })
-      .catch(done);
-    });
-
-    it('should call the callback on success', done => {
-      const counter = new TimestampedCounter(metrics, 'foo');
-      counter.incrby(4, (err, result) => {
-        expect(err).to.equal(null);
-        expect(result).to.equal(4);
-        done();
       });
     });
 
-    it('should resolve a promise on success', done => {
+    it('should resolve on success', () => {
       const counter = new TimestampedCounter(metrics, 'foo');
-      counter.incrby(5).then(result => {
+
+      return counter.incrby(5).then(result => {
         expect(result).to.equal(5);
-        done();
-      })
-      .catch(done);
+      });
     });
 
-    it('should call the callback on error from incrby', done => {
+    it('should reject the promise on redis error from incrby', () => {
       sandbox.stub(metrics.client, 'incrby')
         .yields(new Error('oh no'), null);
 
@@ -532,14 +586,11 @@ describe('Counter', () => {
         'foo',
         { expireKeys: false }
       );
-      counter.incrby(6, (err, result) => {
-        expect(err).to.not.equal(null);
-        expect(result).to.equal(null);
-        done();
-      });
+
+      return ensureError(() => counter.incrby(7));
     });
 
-    it('should call the callback on error from eval', done => {
+    it('should reject the promise on redis error with eval', () => {
       sandbox.stub(metrics.client, 'eval')
         .yields(new Error('oh no'), null);
 
@@ -549,183 +600,122 @@ describe('Counter', () => {
           total: 10
         }
       });
-      counter.incrby(6, (err, result) => {
-        expect(err).to.not.equal(null);
-        expect(result).to.equal(null);
-        done();
-      });
+
+      return ensureError(() => counter.incrby(7));
     });
 
-    it('should reject the promise on redis error from incrby', done => {
-      sandbox.stub(metrics.client, 'incrby')
-        .yields(new Error('oh no'), null);
-
-      const counter = new TimestampedCounter(
-        metrics,
-        'foo',
-        { expireKeys: false }
-      );
-      counter.incrby(7).then(() => {
-        done(new Error('Should not be here'));
-      })
-      .catch(err => {
-        expect(err).to.not.equal(null);
-        done();
-      });
-    });
-
-    it('should reject the promise on redis error with eval', done => {
-      sandbox.stub(metrics.client, 'eval')
-        .yields(new Error('oh no'), null);
-
-      const counter = new TimestampedCounter(metrics, 'foo', {
-        expireKeys: true,
-        expiration: {
-          total: 10
-        }
-      });
-      counter.incrby(7).then(() => {
-        done(new Error('Should not be here'));
-      })
-      .catch(err => {
-        expect(err).to.not.equal(null);
-        done();
-      });
-    });
-
-    it('should return a list of results from the operation', done => {
+    it('should resolve a list of results from the operation', () => {
       const counter = new TimestampedCounter(metrics, 'foo', {
         timeGranularity: 'year'
       });
 
-      counter.incrby(8).then(results => {
+      return counter.incrby(8).then(results => {
         expect(results).to.be.instanceof(Array);
         expect(results).to.deep.equal([8, 8]);
-        done();
-      })
-      .catch(done);
+      });
     });
   });
 
   describe('incrby with event object', () => {
-    it('should work with an event object', done => {
+    it('should work with an event object', () => {
       const counter = new TimestampedCounter(metrics, 'foo');
 
-      counter.incrby(9, 'bar').then(result => {
+      return counter.incrby(9, { eventObj: 'bar' }).then(result => {
         expect(Number(result)).to.equal(9);
-        done();
-      })
-      .catch(done);
+      });
     });
 
-    it('should work with an event object and time granularity', done => {
+    it('should work with an event object and time granularity', () => {
       const counter = new TimestampedCounter(metrics, 'foo', {
         timeGranularity: 'year'
       });
 
-      counter.incrby(10, 'bar').then(results => {
+      return counter.incrby(10, { eventObj: 'bar' }).then(results => {
         expect(utils.parseIntArray(results)).to.deep.equal([10, 10]);
-        done();
-      })
-      .catch(done);
+      });
+    });
+  });
+
+  describe('incrby with expiration', () => {
+    it('should set a ttl for a key', () => {
+      const counter = new TimestampedCounter(metrics, 'foo', {
+        expireKeys: true,
+        expiration: {
+          total: 60 // Gone in 60 seconds :-)
+        }
+      });
+
+      return counter.incrby(10)
+        .then(() => {
+          const [key] = counter.getKeys();
+          return utils.ninvoke(metrics.client, 'ttl', key);
+        })
+        .then(ttl => {
+          expect(ttl).to.be.above(0);
+          expect(ttl).to.be.most(60);
+        });
+    });
+
+    it('should set a ttl for a key with event objects', () => {
+      const counter = new TimestampedCounter(metrics, 'foo', {
+        expireKeys: true,
+        expiration: {
+          total: 100
+        }
+      });
+
+      return counter.incrby(10, { eventObj: 'bar' })
+        .then(() => {
+          const key = counter.getKeys()[0] + ':z';
+          return utils.ninvoke(metrics.client, 'ttl', key);
+        })
+        .then(ttl => {
+          expect(ttl).to.be.above(0);
+          expect(ttl).to.be.most(100);
+        });
     });
   });
 
   describe('count', () => {
-    it('should work with callback', done => {
-      const mock = sandbox.mock(metrics.client)
-        .expects('get')
-        .once()
-        .yields(null, '10');
-
-      const counter = new TimestampedCounter(metrics, 'foo');
-      counter.count((err, result) => {
-        mock.verify();
-        expect(result).to.equal(10);
-        done(err);
-      });
-    });
-
-    it('should work with time granularity and callback', done => {
-      const mock = sandbox.mock(metrics.client)
-        .expects('get')
-        .once()
-        .yields(null, '10');
-
-      const counter = new TimestampedCounter(metrics, 'foo');
-      counter.count('none', (err, result) => {
-        mock.verify();
-        expect(result).to.equal(10);
-        done(err);
-      });
-    });
-
-    it('should work with time gran, event object and callback', done => {
-      const mock = sandbox.mock(metrics.client)
-        .expects('zscore')
-        .once()
-        .yields(null, '10');
-
-      const counter = new TimestampedCounter(metrics, 'foo');
-      counter.count('none', 'bar', (err, result) => {
-        mock.verify();
-        expect(result).to.equal(10);
-        done(err);
-      });
-    });
-
     it('should return a single res when no arg are given', () => {
       const counter = new TimestampedCounter(metrics, 'foo');
-      return counter.incr()
-        .then(() => counter.incr())
-        .then(() => counter.incr())
-        .then(() => counter.count())
-        .then(result => {
-          // Counter has been incremented 3 times.
-          expect(result).to.equal(3);
-        });
+      return Promise.all([
+        counter.incr(),
+        counter.incr(),
+        counter.incr()
+      ])
+      .then(() => counter.count())
+      .then(result => {
+        expect(result).to.equal(3);
+      });
     });
 
     it('should return a single result for an event object', () => {
       const counter = new TimestampedCounter(metrics, 'foo');
-      return counter.incr('bar')
-        .then(() => counter.incr('bar'))
-        .then(() => counter.incr('bar'))
-        .then(() => counter.count('total', 'bar'))
-        .then(result => {
-          // Counter has been incremented 3 times.
-          expect(result).to.equal(3);
-        });
-    });
-
-    it('should return 0 when the key does not exist (cb)', done => {
-      const mock = sandbox.mock(metrics.client)
-        .expects('get')
-        .once()
-        .yields(null, null);
-
-      const counter = new TimestampedCounter(metrics, 'foo');
-      counter.count((err, result) => {
-        mock.verify();
-        expect(result).to.equal(0);
-        done(err);
+      return Promise.all([
+        counter.incr({ eventObj: 'bar' }),
+        counter.incr({ eventObj: 'bar' }),
+        counter.incr({ eventObj: 'bar' })
+      ])
+      .then(() => counter.count({ eventObj: 'bar' }))
+      .then(result => {
+        expect(result).to.equal(3);
       });
     });
 
-    it('should return 0 when the key does not exist (promise)', done => {
+    it('should return 0 when the key does not exist', () => {
       const mock = sandbox.mock(metrics.client)
         .expects('get')
         .once()
         .yields(null, null);
 
       const counter = new TimestampedCounter(metrics, 'foo');
-      counter.count()
+
+      return counter.count()
         .then(result => {
           mock.verify();
           expect(result).to.equal(0);
-          done();
-        })
-        .catch(done);
+        });
     });
 
     it('should return a count for a specific time granularity', () => {
@@ -742,15 +732,15 @@ describe('Counter', () => {
           clock.tick(1000 * 60 * 60 * 24 * 365);
           return counter.incr();
         })
-        .then(() => counter.count('none')) // same as counter.count();
+        .then(() => counter.count()) // same as counter.count();
         .then(result => {
           expect(result).to.equal(2);
-          return counter.count('year');
+          return counter.count({ timeGranularity: 'year' });
         })
         .then(result => expect(result).to.equal(1));
     });
 
-    it('should return a count for a specific time gran and event', () => {
+    it('should return a count for a specific granularity and event', () => {
       const counter = new TimestampedCounter(metrics, 'foo', {
         timeGranularity: 'year'
       });
@@ -759,500 +749,277 @@ describe('Counter', () => {
       // Total should be 2 but year should be 1.
 
       const clock = sandbox.useFakeTimers(new Date('2014-02-01').getTime());
-      return counter.incr('bar')
+      return counter.incr({ eventObj: 'bar' })
         .then(() => {
           clock.tick(1000 * 60 * 60 * 24 * 365);
-          return counter.incr('bar');
+          return counter.incr({ eventObj: 'bar' });
         })
-        .then(() => counter.count('none', 'bar'))
+        .then(() => counter.count({ eventObj: 'bar' }))
         .then(result => {
           expect(result).to.equal(2);
-          return counter.count('year', 'bar');
+          return counter.count({ timeGranularity: 'year', eventObj: 'bar' });
         })
         .then(result => expect(result).to.equal(1));
     });
   });
 
   describe('countRange', () => {
-    it('should return a range of counts', done => {
+    it('should return a range of counts', () => {
       const counter = new TimestampedCounter(metrics, 'foo', {
         timeGranularity: 'year'
       });
 
       // Increment 2014 once and 2015 twice
-
-      const start = moment.utc({ year: 2014 });
-      const end = moment.utc({ year: 2015 });
-      const expected = {};
-      expected[start.format()] = 1;
-      expected[end.format()] = 2;
+      const startDate = moment.utc({ year: 2014 });
+      const endDate = moment.utc({ year: 2015 });
 
       const clock = sandbox.useFakeTimers(new Date('2014-02-01').getTime());
-      counter.incr()
+      return counter.incr()
         .then(() => {
           clock.tick(1000 * 60 * 60 * 24 * 365);
-          return counter.incr();
+          return Promise.all([
+            counter.incr(),
+            counter.incr()
+          ]);
         })
-        .then(() => counter.incr())
-        .then(() => counter.countRange('year', start, end))
+        .then(() => counter.countRange('year', { startDate, endDate }))
         .then(result => {
-          // Check promise
-          expect(result).to.deep.equal(expected);
-
-          // Check callback
-          counter.countRange('year', start, end, (err, res) => {
-            expect(res).to.deep.equal(expected);
-            done();
+          expect(result).to.deep.equal({
+            [startDate.format()]: 1,
+            [endDate.format()]: 2
           });
-        })
-        .catch(done);
+        });
     });
 
-    it('should return a range of counts at the second level', done => {
+    it('should return a range of counts at the second level', () => {
       const counter = new TimestampedCounter(metrics, 'foo', {
         timeGranularity: 'second'
       });
 
-      const start = moment.utc({ year: 2015, second: 0 });
-      const end = moment.utc({ year: 2015, second: 1 });
-      const expected = {};
-      expected[start.format()] = 1;
-      expected[end.format()] = 2;
+      const startDate = moment.utc({ year: 2015, second: 0 });
+      const endDate = moment.utc({ year: 2015, second: 1 });
 
       const clock = sandbox.useFakeTimers(new Date('2015-01-01').getTime());
-      counter.incr()
+      return counter.incr()
         .then(() => {
           clock.tick(1000);
-          return counter.incr();
+          return Promise.all([
+            counter.incr(),
+            counter.incr()
+          ]);
         })
-        .then(() => counter.incr())
-        .then(() => counter.countRange('second', start, end))
+        .then(() => counter.countRange('second', { startDate, endDate }))
         .then(result => {
-          // Check promise
-          expect(result).to.deep.equal(expected);
-
-          // Check callback
-          counter.countRange('second', start, end, (err, res) => {
-            expect(res).to.deep.equal(expected);
-            done();
+          expect(result).to.deep.equal({
+            [startDate.format()]: 1,
+            [endDate.format()]: 2
           });
-        })
-        .catch(done);
+        });
     });
 
-    it('should return a range of count for an event object', done => {
+    it('should return a range of count for an event object', () => {
       const counter = new TimestampedCounter(metrics, 'foo', {
         timeGranularity: 'year'
       });
 
-      // Increment 2014 once and 2015 twice
-
-      const start = moment.utc({ year: 2014 });
-      const end = moment.utc({ year: 2015 });
-      const expected = {};
-      expected[start.format()] = 1;
-      expected[end.format()] = 2;
+      const startDate = moment.utc({ year: 2014 });
+      const endDate = moment.utc({ year: 2015 });
 
       const clock = sandbox.useFakeTimers(new Date('2014-02-01').getTime());
-      counter.incr('bar')
+      return counter.incr({ eventObj: 'bar' })
         .then(() => {
           clock.tick(1000 * 60 * 60 * 24 * 365);
-          return counter.incr('bar');
+          return Promise.all([
+            counter.incr({ eventObj: 'bar' }),
+            counter.incr({ eventObj: 'bar' })
+          ]);
         })
-        .then(() => counter.incr('bar'))
-        .then(() => counter.countRange('year', start, end, 'bar'))
+        .then(() => counter.countRange('year', { startDate, endDate }, { eventObj: 'bar' }))
         .then(result => {
-          // Check promise
-          expect(result).to.deep.equal(expected);
-
-          // Check callback
-          counter.countRange('year', start, end, 'bar', (err, res) => {
-            expect(res).to.deep.equal(expected);
-            done();
+          expect(result).to.deep.equal({
+            [startDate.format()]: 1,
+            [endDate.format()]: 2
           });
-        })
-        .catch(done);
+        });
     });
 
-    it('should use current date if no end date is provided', done => {
+    it('should use current date if no end date is provided', () => {
       const counter = new TimestampedCounter(metrics, 'foo', {
         timeGranularity: 'year'
       });
 
-      // Increment 2014 once and 2015 twice
-
-      const start = moment.utc({ year: 2014 });
-      const expected = {};
-      expected[start.format()] = 1;
-      expected[moment.utc(start).add(1, 'years').format()] = 2;
+      const startDate = moment.utc({ year: 2014 });
 
       const clock = sandbox.useFakeTimers(new Date('2014-02-01').getTime());
-      counter.incr()
+      return counter.incr()
         .then(() => {
           clock.tick(1000 * 60 * 60 * 24 * 365);
-          return counter.incr();
+          return Promise.all([
+            counter.incr(),
+            counter.incr()
+          ]);
         })
-        .then(() => counter.incr())
-        .then(() => counter.countRange('year', start))
+        .then(() => counter.countRange('year', { startDate }))
         .then(result => {
-          // Check promise
-          expect(result).to.deep.equal(expected);
-
-          // Check callback
-          counter.countRange('year', start, (err, res) => {
-            expect(res).to.deep.equal(expected);
-            done();
+          expect(result).to.deep.equal({
+            [startDate.format()]: 1,
+            [moment.utc(startDate).add(1, 'years').format()]: 2
           });
-        })
-        .catch(done);
+        });
     });
 
-    it('should return 0 for counters where no data registed', done => {
+    it('should return 0 for counters where no data registed', () => {
       const counter = new TimestampedCounter(metrics, 'foo', {
         timeGranularity: 'year'
       });
 
       // Increment 2014 once.
-
-      const start = moment.utc({ year: 2014 });
-      const end = moment.utc({ year: 2015 });
-      const expected = {};
-      expected[start.format()] = 1;
-      expected[end.format()] = 0;
+      const startDate = moment.utc({ year: 2014 });
+      const endDate = moment.utc({ year: 2015 });
 
       sandbox.useFakeTimers(new Date('2014-02-01').getTime());
-      counter.incr()
-        .then(() => counter.countRange('year', start, end))
+      return counter.incr()
+        .then(() => counter.countRange('year', { startDate, endDate }))
         .then(result => {
-          // Check promise
-          expect(result).to.deep.equal(expected);
-
-          // Check callback
-          counter.countRange('year', start, end, (err, res) => {
-            expect(res).to.deep.equal(expected);
-            done();
+          expect(result).to.deep.equal({
+            [startDate.format()]: 1,
+            [endDate.format()]: 0
           });
-        })
-        .catch(done);
+        });
     });
 
-    it('should return 0 for counters where no data is reg', done => {
+    it('should return 0 for eventObj counters where no data is registered', () => {
       const counter = new TimestampedCounter(metrics, 'foo', {
         timeGranularity: 'year'
       });
 
       // Increment 2014 once.
-
-      const start = moment.utc({ year: 2014 });
-      const end = moment.utc({ year: 2015 });
-      const expected = {};
-      expected[start.format()] = 1;
-      expected[end.format()] = 0;
+      const startDate = moment.utc({ year: 2014 });
+      const endDate = moment.utc({ year: 2015 });
 
       sandbox.useFakeTimers(new Date('2014-02-01').getTime());
-      counter.incr('bar')
-        .then(() => counter.countRange('year', start, end, 'bar'))
+      return counter.incr({ eventObj: 'bar' })
+        .then(() => counter.countRange('year', { startDate, endDate }, { eventObj: 'bar' }))
         .then(result => {
-          // Check promise
-          expect(result).to.deep.equal(expected);
-
-          // Check callback
-          counter.countRange('year', start, end, 'bar', (err, res) => {
-            expect(res).to.deep.equal(expected);
-            done();
+          expect(result).to.deep.equal({
+            [startDate.format()]: 1,
+            [endDate.format()]: 0
           });
-        })
-        .catch(done);
+        });
     });
 
-    it('should accept strings for date range', done => {
+    it('should accept strings for date range', () => {
       const counter = new TimestampedCounter(metrics, 'foo', {
         timeGranularity: 'year'
       });
 
-      // Increment 2014 once and 2015 twice
-
-      const start = moment.utc({ year: 2014 });
-      const end = moment.utc({ year: 2015 });
-      const expected = {};
-      expected[start.format()] = 1;
-      expected[end.format()] = 2;
+      const startDate = moment.utc({ year: 2014 });
+      const endDate = moment.utc({ year: 2015 });
 
       const startStr = '2014-01-01T00:00:00Z';
       const endStr = '2015-01-01T00:00:00Z';
 
       const clock = sandbox.useFakeTimers(new Date('2014-02-01').getTime());
-      counter.incr()
+      return counter.incr()
         .then(() => {
           clock.tick(1000 * 60 * 60 * 24 * 365);
-          return counter.incr();
+          return Promise.all([
+            counter.incr(),
+            counter.incr()
+          ]);
         })
-        .then(() => counter.incr())
-        .then(() => counter.countRange('year', startStr, endStr))
+        .then(() => counter.countRange('year', { startDate: startStr, endDate: endStr }))
         .then(result => {
-          // Check promise
-          expect(result).to.deep.equal(expected);
-
-          // Check callback
-          counter.countRange('year', startStr, endStr, (err, res) => {
-            expect(res).to.deep.equal(expected);
-            done();
+          expect(result).to.deep.equal({
+            [startDate.format()]: 1,
+            [endDate.format()]: 2
           });
-        })
-        .catch(done);
+        });
     });
 
-    it('should accept numbers for date range', done => {
+    it('should accept numbers for date range', () => {
       const counter = new TimestampedCounter(metrics, 'foo', {
         timeGranularity: 'year'
       });
 
-      // Increment 2014 once and 2015 twice
-
       const start = moment.utc({ year: 2014 });
       const end = moment.utc({ year: 2015 });
-      const expected = {};
-      expected[start.format()] = 1;
-      expected[end.format()] = 2;
 
       const startNum = start.valueOf();
       const endNum = end.valueOf();
 
       const clock = sandbox.useFakeTimers(new Date('2014-02-01').getTime());
-      counter.incr()
+      return counter.incr()
         .then(() => {
           clock.tick(1000 * 60 * 60 * 24 * 365);
-          return counter.incr();
+          return Promise.all([
+            counter.incr(),
+            counter.incr()
+          ]);
         })
-        .then(() => counter.incr())
-        .then(() => counter.countRange('year', startNum, endNum))
+        .then(() => counter.countRange('year', { startDate: startNum, endDate: endNum }))
         .then(result => {
-          // Check promise
-          expect(result).to.deep.equal(expected);
-
-          // Check callback
-          counter.countRange('year', startNum, endNum, (err, res) => {
-            expect(res).to.deep.equal(expected);
-            done();
+          expect(result).to.deep.equal({
+            [start.format()]: 1,
+            [end.format()]: 2
           });
-        })
-        .catch(done);
+        });
     });
 
-    it('should return a single num if "total" granularity is selected', done => {
+    it('should return a single num if "total" granularity is selected', () => {
       const counter = new TimestampedCounter(metrics, 'foo', {
         timeGranularity: 'year'
       });
 
       // Increment 2014 once and 2015 twice => total is 3
-
-      const start = moment.utc({ year: 2014 });
-      const end = moment.utc({ year: 2015 });
+      const startDate = moment.utc({ year: 2014 });
+      const endDate = moment.utc({ year: 2015 });
 
       const clock = sandbox.useFakeTimers(new Date('2014-02-01').getTime());
-      counter.incr()
+      return counter.incr()
         .then(() => {
           clock.tick(1000 * 60 * 60 * 24 * 365);
-          return counter.incr();
+          return Promise.all([
+            counter.incr(),
+            counter.incr()
+          ]);
         })
-        .then(() => counter.incr())
-        .then(() => counter.countRange('total', start, end))
+        .then(() => counter.countRange('total', { startDate, endDate }))
         .then(result => {
-          // Check promise
           expect(result).to.equal(3);
-
-          // Check callback
-          counter.countRange('total', start, end, (err, res) => {
-            expect(res).to.equal(3);
-            done();
-          });
-        })
-        .catch(done);
+        });
     });
 
-    it('should throw an exc if countRange is used on a counter', () => {
+    it('should reject if countRange is used on a counter', () => {
       const counter = new TimestampedCounter(metrics, 'foo', {
         timeGranularity: 'total'
       });
 
-      const throwClosure = () => counter.countRange('total', '2015', '2016');
-      expect(throwClosure).to.throw(Error);
-    });
-  });
-
-  describe('incr with expiration', () => {
-    it('should set a ttl for a key', done => {
-      const counter = new TimestampedCounter(metrics, 'foo', {
-        expireKeys: true,
-        expiration: {
-          total: 100
-        }
-      });
-
-      counter.incr().then(() => {
-        const key = counter.getKeys()[0];
-        metrics.client.ttl(key, (err, ttl) => {
-          expect(err).to.equal(null);
-          expect(ttl).to.be.above(0);
-          expect(ttl).to.be.most(100);
-          done();
-        });
-      })
-      .catch(done);
-    });
-
-    it('should set a ttl for a key with event objects', done => {
-      const counter = new TimestampedCounter(metrics, 'foo', {
-        expireKeys: true,
-        expiration: {
-          total: 100
-        }
-      });
-
-      counter.incr('bar').then(() => {
-        const key = counter.getKeys()[0] + ':z';
-        metrics.client.ttl(key, (err, ttl) => {
-          expect(err).to.equal(null);
-          expect(ttl).to.be.above(0);
-          expect(ttl).to.be.most(100);
-          done();
-        });
-      })
-      .catch(done);
-    });
-
-    it('should not renew the ttl on the second call', done => {
-      const counter = new TimestampedCounter(metrics, 'foo', {
-        expireKeys: true,
-        expiration: {
-          total: 100
-        }
-      });
-
-      counter.incr().then(() => {
-        const key = counter.getKeys()[0];
-        metrics.client.ttl(key, (err, ttl) => {
-          setTimeout(() => {
-            counter.incr().then(() => {
-              metrics.client.ttl(key, (err2, ttl2) => {
-                // Expect that ttl has decreased.
-                expect(ttl2).to.be.below(ttl);
-                expect(ttl2).to.be.within(ttl - 2, ttl);
-                done();
-              });
-            });
-          }, 1100);
-        });
-      })
-      .catch(done);
-    });
-
-    it('should not renew the ttl on the second call', done => {
-      const counter = new TimestampedCounter(metrics, 'foo', {
-        expireKeys: true,
-        expiration: {
-          total: 100
-        }
-      });
-
-      counter.incr('bar').then(() => {
-        const key = counter.getKeys()[0] + ':z';
-        metrics.client.ttl(key, (err, ttl) => {
-          setTimeout(() => {
-            counter.incr('bar').then(() => {
-              metrics.client.ttl(key, (err2, ttl2) => {
-                // Expect that ttl has decreased.
-                expect(ttl2).to.be.below(ttl);
-                expect(ttl2).to.be.within(ttl - 2, ttl);
-                done();
-              });
-            });
-          }, 1100);
-        });
-      })
-      .catch(done);
-    });
-  });
-
-  describe('incrby with expiration', () => {
-    it('should set a ttl for a key', done => {
-      const counter = new TimestampedCounter(metrics, 'foo', {
-        expireKeys: true,
-        expiration: {
-          total: 60 // Gone in 60 seconds :-)
-        }
-      });
-
-      counter.incrby(10).then(() => {
-        const key = counter.getKeys()[0];
-        metrics.client.ttl(key, (err, ttl) => {
-          expect(err).to.equal(null);
-          expect(ttl).to.be.above(0);
-          expect(ttl).to.be.most(60);
-          done();
-        });
-      })
-      .catch(done);
-    });
-
-    it('should set a ttl for a key with event objects', done => {
-      const counter = new TimestampedCounter(metrics, 'foo', {
-        expireKeys: true,
-        expiration: {
-          total: 100
-        }
-      });
-
-      counter.incrby(10, 'bar').then(() => {
-        const key = counter.getKeys()[0] + ':z';
-        metrics.client.ttl(key, (err, ttl) => {
-          expect(err).to.equal(null);
-          expect(ttl).to.be.above(0);
-          expect(ttl).to.be.most(100);
-          done();
-        });
-      })
-      .catch(done);
+      return ensureError(
+        () => counter.countRange('total', { startDate: '2015', endDate: '2016' }),
+        err => expect(/total granularity/.test(err.message)).to.be.true
+      );
     });
   });
 
   describe('top', () => {
-    it('should work with callback', done => {
-      const mock = sandbox.mock(metrics.client)
-        .expects('zrevrange')
-        .once()
-        .withArgs('c:foo:z', 0, -1, 'WITHSCORES')
-        .yields(null, ['foo', '39', 'bar', '13']);
-
-      const counter = new TimestampedCounter(metrics, 'foo');
-      counter.top('foo', (err, results) => {
-        mock.verify();
-        expect(results).to.have.length(2);
-        expect(results[0]).to.have.property('foo');
-        expect(results[0].foo).to.equal(39);
-        done(err);
-      });
-    });
-
-    it('should work with promises', done => {
+    it('should resolve the toplist', () => {
       const mock = sandbox.mock(metrics.client)
         .expects('zrevrange')
         .once()
         .yields(null, ['foo', '39', 'bar', '13']);
 
       const counter = new TimestampedCounter(metrics, 'foo');
-      counter.top('foo')
+      return counter.top()
         .then(results => {
           mock.verify();
           expect(results).to.have.length(2);
           expect(results[0]).to.have.property('foo');
           expect(results[0].foo).to.equal(39);
-          done();
-        })
-        .catch(done);
+        });
     });
 
-    it('should accept a startingAt argument', done => {
+    it('should accept a startingAt option', () => {
       const mock = sandbox.mock(metrics.client)
         .expects('zrevrange')
         .once()
@@ -1260,13 +1027,11 @@ describe('Counter', () => {
         .yields(null, ['foo', '39', 'bar', '13']);
 
       const counter = new TimestampedCounter(metrics, 'foo');
-      counter.top('foo', 'desc', 10, err => {
-        mock.verify();
-        done(err);
-      });
+      return counter.top({ startingAt: 10 })
+        .then(() => mock.verify());
     });
 
-    it('should accept a startingAt and a limit argument', done => {
+    it('should accept startingAt and limit options', () => {
       const mock = sandbox.mock(metrics.client)
         .expects('zrevrange')
         .once()
@@ -1274,13 +1039,11 @@ describe('Counter', () => {
         .yields(null, ['foo', '39', 'bar', '13']);
 
       const counter = new TimestampedCounter(metrics, 'foo');
-      counter.top('foo', 'desc', 10, 15, err => {
-        mock.verify();
-        done(err);
-      });
+      return counter.top({ startingAt: 10, limit: 15 })
+        .then(() => mock.verify());
     });
 
-    it('should accept a direction argument with asc value', done => {
+    it('should accept a direction option with asc value', () => {
       const mock = sandbox.mock(metrics.client)
         .expects('zrange')
         .once()
@@ -1288,28 +1051,24 @@ describe('Counter', () => {
         .yields(null, ['foo', '39', 'bar', '13']);
 
       const counter = new TimestampedCounter(metrics, 'foo');
-      counter.top('foo', 'asc', err => {
-        mock.verify();
-        done(err);
-      });
+      return counter.top({ direction: 'asc' })
+        .then(() => mock.verify());
     });
 
-    it('should throw an exception if the direction argument is not correct', done => {
+    it('should reject if the direction option is invalid', () => {
       const counter = new TimestampedCounter(metrics, 'foo');
-      try {
-        counter.top('foo', 'dummy');
-      } catch (e) {
-        return done();
-      }
 
-      throw new Error('This should never be called.');
+      return ensureError(
+        () => counter.top({ direction: 'dummy' }),
+        err => expect(err.message).to.match(/direction/)
+      );
     });
 
     it('should work with a real Redis connection', () => {
       const counter = new TimestampedCounter(metrics, 'foo');
 
-      return counter.incrby(5, '/page1')
-        .then(() => counter.incrby(3, '/page2'))
+      return counter.incrby(5, { eventObj: '/page1' })
+        .then(() => counter.incrby(3, { eventObj: '/page2' }))
         .then(() => counter.top())
         .then(results => expect(results).to.eql([
           { '/page1': 5 },
@@ -1319,292 +1078,194 @@ describe('Counter', () => {
   });
 
   describe('topRange', () => {
-    it('should return toplists within the given range', done => {
+    it('should return toplists within the given range', () => {
       const counter = new TimestampedCounter(metrics, 'foo', { timeGranularity: 'year' });
 
-      const start = moment.utc({ year: 2014 });
-      const end = moment.utc({ year: 2015 });
-      const expected = {};
-      expected[start.format()] = [{ two: 2 }, { one: 1 }];
-      expected[end.format()] = [{ two: 4 }, { one: 2 }];
+      const startDate = moment.utc({ year: 2014 });
+      const endDate = moment.utc({ year: 2015 });
 
       const clock = sandbox.useFakeTimers(new Date('2014-02-01').getTime());
 
-      Promise.all([
-        counter.incr('one'),
-        counter.incr('two'),
-        counter.incr('two')
+      return Promise.all([
+        counter.incr({ eventObj: 'one' }),
+        counter.incrby(2, { eventObj: 'two' })
       ])
       .then(() => {
         clock.tick(1000 * 60 * 60 * 24 * 365);
         return Promise.all([
-          counter.incr('one'),
-          counter.incr('one'),
-          counter.incr('two'),
-          counter.incr('two'),
-          counter.incr('two'),
-          counter.incr('two')
+          counter.incrby(2, { eventObj: 'one' }),
+          counter.incrby(4, { eventObj: 'two' })
         ]);
       })
-      .then(() => counter.topRange(start, end, 'year'))
+      .then(() => counter.topRange({ startDate, endDate }, { timeGranularity: 'year' }))
       .then(result => {
-        // Check promise
-        expect(result).to.deep.equal(expected);
-
-        // Check callback
-        counter.topRange(start, end, 'year', (err, res) => {
-          expect(res).to.deep.equal(expected);
-          done();
+        expect(result).to.deep.equal({
+          [startDate.format()]: [{ two: 2 }, { one: 1 }],
+          [endDate.format()]: [{ two: 4 }, { one: 2 }]
         });
-      })
-      .catch(done);
+      });
     });
 
-    it('should merge toplists within the given range if given "total" granularity', done => {
+    it('should merge toplists within the given range if given "total" granularity', () => {
       const counter = new TimestampedCounter(metrics, 'foo', { timeGranularity: 'year' });
 
-      const start = moment.utc({ year: 2014 });
-      const end = moment.utc({ year: 2015 });
-      const expected = [{ two: 6 }, { one: 3 }];
+      const startDate = moment.utc({ year: 2014 });
+      const endDate = moment.utc({ year: 2015 });
 
       const clock = sandbox.useFakeTimers(new Date('2014-02-01').getTime());
 
-      Promise.all([
-        counter.incr('one'),
-        counter.incr('two'),
-        counter.incr('two')
+      return Promise.all([
+        counter.incr({ eventObj: 'one' }),
+        counter.incrby(2, { eventObj: 'two' })
       ])
       .then(() => {
         clock.tick(1000 * 60 * 60 * 24 * 365);
         return Promise.all([
-          counter.incr('one'),
-          counter.incr('one'),
-          counter.incr('two'),
-          counter.incr('two'),
-          counter.incr('two'),
-          counter.incr('two')
+          counter.incrby(2, { eventObj: 'one' }),
+          counter.incrby(4, { eventObj: 'two' })
         ]);
       })
       .then(() => {
         clock.tick(1000 * 60 * 60 * 24 * 365);
         return Promise.all([
-          counter.incr('one'),
-          counter.incr('two')
+          counter.incr({ eventObj: 'one' }),
+          counter.incr({ eventObj: 'two' })
         ]);
       })
-      .then(() => counter.topRange(start, end, 'total'))
+      .then(() => counter.topRange({ startDate, endDate }, { timeGranularity: 'total' }))
       .then(result => {
-        // Check promise
-        expect(result).to.deep.equal(expected);
-
-        // Check callback
-        counter.topRange(start, end, 'total', (err, res) => {
-          expect(res).to.deep.equal(expected);
-          done();
-        });
-      })
-      .catch(done);
+        expect(result).to.deep.equal([{ two: 6 }, { one: 3 }]);
+      });
     });
 
-    it('can be customized with direction, startingAt and limit', done => {
+    it('can be customized with direction, startingAt and limit', () => {
       const counter = new TimestampedCounter(metrics, 'foo', { timeGranularity: 'year' });
 
-      const start = moment.utc({ year: 2014 });
-      const end = moment.utc({ year: 2015 });
-      const expected = {};
-      expected[start.format()] = [{ two: 2 }, { three: 3 }];
-      expected[end.format()] = [{ two: 4 }, { three: 6 }];
+      const startDate = moment.utc({ year: 2014 });
+      const endDate = moment.utc({ year: 2015 });
 
       const clock = sandbox.useFakeTimers(new Date('2014-02-01').getTime());
-
-      Promise.all([
-        counter.incr('one'),
-        counter.incr('two'),
-        counter.incr('two'),
-        counter.incr('three'),
-        counter.incr('three'),
-        counter.incr('three'),
-        counter.incr('four'),
-        counter.incr('four'),
-        counter.incr('four'),
-        counter.incr('four')
+      return Promise.all([
+        counter.incr({ eventObj: 'one' }),
+        counter.incrby(2, { eventObj: 'two' }),
+        counter.incrby(3, { eventObj: 'three' }),
+        counter.incrby(4, { eventObj: 'four' })
       ])
       .then(() => {
         clock.tick(1000 * 60 * 60 * 24 * 365);
         return Promise.all([
-          counter.incr('one'),
-          counter.incr('one'),
-          counter.incr('two'),
-          counter.incr('two'),
-          counter.incr('two'),
-          counter.incr('two'),
-          counter.incr('three'),
-          counter.incr('three'),
-          counter.incr('three'),
-          counter.incr('three'),
-          counter.incr('three'),
-          counter.incr('three'),
-          counter.incr('four'),
-          counter.incr('four'),
-          counter.incr('four'),
-          counter.incr('four'),
-          counter.incr('four'),
-          counter.incr('four'),
-          counter.incr('four'),
-          counter.incr('four')
+          counter.incrby(2, { eventObj: 'one' }),
+          counter.incrby(4, { eventObj: 'two' }),
+          counter.incrby(6, { eventObj: 'three' }),
+          counter.incrby(8, { eventObj: 'four' })
         ]);
       })
-      .then(() => counter.topRange(start, end, 'year', 'asc', 1, 2))
+      .then(() => counter.topRange(
+        { startDate, endDate },
+        { timeGranularity: 'year', direction: 'asc', startingAt: 1, limit: 2 }
+      ))
       .then(result => {
-        // Check promise
-        expect(result).to.deep.equal(expected);
-
-        // Check callback
-        counter.topRange(start, end, 'year', 'asc', 1, 2, (err, res) => {
-          expect(res).to.deep.equal(expected);
-          done();
+        expect(result).to.deep.equal({
+          [startDate.format()]: [{ two: 2 }, { three: 3 }],
+          [endDate.format()]: [{ two: 4 }, { three: 6 }]
         });
-      })
-      .catch(done);
+      });
     });
 
-    it('can be customized with direction, startingAt and limit, on "total" granularity', done => {
+    it('can be customized with direction, startingAt and limit, on "total" granularity', () => {
       const counter = new TimestampedCounter(metrics, 'foo', { timeGranularity: 'year' });
 
-      const start = moment.utc({ year: 2014 });
-      const end = moment.utc({ year: 2015 });
-      const expected = [{ two: 7 }, { three: 8 }];
+      const startDate = moment.utc({ year: 2014 });
+      const endDate = moment.utc({ year: 2015 });
 
       const clock = sandbox.useFakeTimers(new Date('2014-02-01').getTime());
 
       // orders are inverted in this first call to make sure that results
       // are not trimmed in the initial zscore calls
-      Promise.all([
-        counter.incr('one'),
-        counter.incr('one'),
-        counter.incr('one'),
-        counter.incr('one'),
-        counter.incr('two'),
-        counter.incr('two'),
-        counter.incr('two'),
-        counter.incr('three'),
-        counter.incr('three'),
-        counter.incr('four')
+      return Promise.all([
+        counter.incrby(4, { eventObj: 'one' }),
+        counter.incrby(3, { eventObj: 'two' }),
+        counter.incrby(2, { eventObj: 'three' }),
+        counter.incr({ eventObj: 'four' })
       ])
       .then(() => {
         clock.tick(1000 * 60 * 60 * 24 * 365);
         return Promise.all([
-          counter.incr('one'),
-          counter.incr('one'),
-          counter.incr('two'),
-          counter.incr('two'),
-          counter.incr('two'),
-          counter.incr('two'),
-          counter.incr('three'),
-          counter.incr('three'),
-          counter.incr('three'),
-          counter.incr('three'),
-          counter.incr('three'),
-          counter.incr('three'),
-          counter.incr('four'),
-          counter.incr('four'),
-          counter.incr('four'),
-          counter.incr('four'),
-          counter.incr('four'),
-          counter.incr('four'),
-          counter.incr('four'),
-          counter.incr('four')
+          counter.incrby(2, { eventObj: 'one' }),
+          counter.incrby(4, { eventObj: 'two' }),
+          counter.incrby(6, { eventObj: 'three' }),
+          counter.incrby(8, { eventObj: 'four' })
         ]);
       })
       .then(() => {
         clock.tick(1000 * 60 * 60 * 24 * 365);
         return Promise.all([
-          counter.incr('one'),
-          counter.incr('two')
+          counter.incr({ eventObj: 'one' }),
+          counter.incr({ eventObj: 'two' })
         ]);
       })
-      .then(() => counter.topRange(start, end, 'total', 'asc', 1, 2))
+      .then(() => counter.topRange(
+        { startDate, endDate },
+        { timeGranularity: 'total', direction: 'asc', startingAt: 1, limit: 2 }
+      ))
       .then(result => {
-        // Check promise
-        expect(result).to.deep.equal(expected);
-
-        // Check callback
-        counter.topRange(start, end, 'total', 'asc', 1, 2, (err, res) => {
-          expect(res).to.deep.equal(expected);
-          done();
-        });
-      })
-      .catch(done);
+        expect(result).to.deep.equal([{ two: 7 }, { three: 8 }]);
+      });
     });
 
-    it('should throw an exc if no from date is given', () => {
-      const counter = new TimestampedCounter(metrics, 'foo', {
-        timeGranularity: 'total'
-      });
+    it('should reject if no start date is given', () => {
+      const counter = new TimestampedCounter(metrics, 'foo', { timeGranularity: 'year' });
 
-      const throwClosure = () => counter.topRange();
-      expect(throwClosure).to.throw(Error);
+      return ensureError(
+        () => counter.topRange({}),
+        err => expect(err.message).to.match(/startDate/)
+      );
     });
 
     it('should throw an exc if an unsupported direction is given', () => {
-      const counter = new TimestampedCounter(metrics, 'foo', {
-        timeGranularity: 'total'
-      });
+      const counter = new TimestampedCounter(metrics, 'foo', { timeGranularity: 'year' });
 
-      const throwClosure = () => counter.topRange(new Date(), new Date(), 'total', 1);
-      expect(throwClosure).to.throw(Error);
+      return ensureError(
+        () => counter.topRange(new Date(), { direction: 1 }),
+        err => expect(err.message).to.match(/direction option/)
+      );
     });
   });
 
   describe('trimEvents', () => {
     let counter;
+
     beforeEach(() => {
       counter = new TimestampedCounter(metrics, 'fruits', {
         timeGranularity: 'hour'
       });
       return Promise.all([
-        counter.incrby(10, 'apples'),
-        counter.incrby(8, 'oranges'),
-        counter.incrby(7, 'pears'),
-        counter.incrby(5, 'peaches'),
-        counter.incrby(2, 'mangos')
+        counter.incrby(10, { eventObj: 'apples' }),
+        counter.incrby(8, { eventObj: 'oranges' }),
+        counter.incrby(7, { eventObj: 'pears' }),
+        counter.incrby(5, { eventObj: 'peaches' }),
+        counter.incrby(2, { eventObj: 'mangos' })
       ]);
     });
 
-    it('should throw an exception if the direction argument is not correct', done => {
-      try {
-        counter.trimEvents('dummy');
-      } catch (e) {
-        return done();
-      }
-
-      throw new Error('This should never be called.');
+    it('should reject if the direction argument is not correct', () => {
+      return ensureError(
+        () => counter.trimEvents({ direction: 'dummy' }),
+        err => expect(err.message).to.match(/direction/)
+      );
     });
 
-    it('should resolve to a failure if a subcommand fails', done => {
+    it('should reject if a subcommand fails', () => {
       sandbox.stub(metrics.client, 'zremrangebyrank')
         .yields(new Error('oh no'));
-      counter.trimEvents()
-        .then(() => done(new Error('should not be here')))
-        .catch(err => {
-          expect(err).to.be.an('error');
-          expect(err.message).to.equal('oh no');
-          done();
-        });
-    });
 
-    it('should call the callback with an error if a subcommand fails', done => {
-      sandbox.stub(metrics.client, 'zremrangebyrank')
-        .yields(new Error('oh no'));
-      counter.trimEvents(err => {
-        try {
+      return ensureError(
+        () => counter.trimEvents(),
+        err => {
           expect(err).to.be.an('error');
           expect(err.message).to.equal('oh no');
-          done();
-        } catch (e) {
-          done(e);
         }
-      });
+      );
     });
 
     it('should trim to 1000 elements by default', () => {
@@ -1618,7 +1279,7 @@ describe('Counter', () => {
     });
 
     it('should support descending trim', () => {
-      return counter.trimEvents('desc', 3)
+      return counter.trimEvents({ direction: 'desc', limit: 3 })
         .then(removed => {
           // It removed 2 from total, 2 from year, 2 from month and 2 from day.
           expect(removed).to.equal(8);
@@ -1635,7 +1296,7 @@ describe('Counter', () => {
     });
 
     it('should support ascending trim', () => {
-      return counter.trimEvents('asc', 3)
+      return counter.trimEvents({ direction: 'asc', limit: 3 })
         .then(removed => {
           // It removed 2 from total, 2 from year, 2 from month and 2 from day.
           expect(removed).to.equal(8);
@@ -1651,18 +1312,6 @@ describe('Counter', () => {
             { mangos: 2 }
           ]);
         });
-    });
-
-    it('should support a callback', done => {
-      counter.trimEvents('desc', 3, (err, removed) => {
-        try {
-          expect(err).to.equal(null);
-          expect(removed).to.equal(8);
-          done();
-        } catch (e) {
-          done(e);
-        }
-      });
     });
 
     context('given a counter with only total granularity', () => {
@@ -1683,7 +1332,7 @@ describe('Counter', () => {
       });
 
       it('should support descending trim', () => {
-        return counter.trimEvents('desc', 3)
+        return counter.trimEvents({ direction: 'desc', limit: 3 })
           .then(removed => {
             expect(removed).to.equal(2);
             return counter.top();
@@ -1699,7 +1348,7 @@ describe('Counter', () => {
       });
 
       it('should support ascending trim', () => {
-        return counter.trimEvents('asc', 3)
+        return counter.trimEvents({ direction: 'asc', limit: 3 })
           .then(removed => {
             expect(removed).to.equal(2);
             return counter.top();
@@ -1731,12 +1380,12 @@ describe('Counter', () => {
           return counter.incr();
         })
         .then(() => counter.incr())
-        .then(() => counter.count('total'))
+        .then(() => counter.count())
         .then(count => {
           expect(count).to.equal(3);
           return counter.zero();
         })
-        .then(() => counter.count('total'))
+        .then(() => counter.count())
         .then(count => expect(count).to.equal(0));
     });
 
@@ -1744,12 +1393,12 @@ describe('Counter', () => {
       const counter = new TimestampedCounter(metrics, 'foo');
 
       return Promise.all([counter.incr(), counter.incr()])
-        .then(() => counter.count('total'))
+        .then(() => counter.count())
         .then(count => {
           expect(count).to.equal(2);
           return counter.zero();
         })
-        .then(() => counter.count('total'))
+        .then(() => counter.count())
         .then(count => expect(count).to.equal(0));
     });
 
@@ -1760,26 +1409,32 @@ describe('Counter', () => {
 
       const clock = sandbox.useFakeTimers(new Date('2014-02-01').getTime());
       return Promise.all([
-        counter.incrby(2, 'five'),
-        counter.incr('two')
+        counter.incrby(2, { eventObj: 'five' }),
+        counter.incr({ eventObj: 'two' })
       ])
       .then(() => {
         clock.tick(1000 * 60 * 60 * 24 * 365);
         return Promise.all([
-          counter.incrby(3, 'five'),
-          counter.incr('two')
+          counter.incrby(3, { eventObj: 'five' }),
+          counter.incr({ eventObj: 'two' })
         ]);
       })
-      .then(() => Promise.all([counter.count('total', 'five'), counter.count('total', 'two')]))
-      .then(res => {
-        expect(res[0]).to.equal(5);
-        expect(res[1]).to.equal(2);
-        return counter.zero('five');
+      .then(() => Promise.all([
+        counter.count({ eventObj: 'five' }),
+        counter.count({ eventObj: 'two' })
+      ]))
+      .then(([fiveCount, twoCount]) => {
+        expect(fiveCount).to.equal(5);
+        expect(twoCount).to.equal(2);
+        return counter.zero({ eventObj: 'five' });
       })
-      .then(() => Promise.all([counter.count('total', 'five'), counter.count('total', 'two')]))
-      .then(res => {
-        expect(res[0]).to.equal(0);
-        expect(res[1]).to.equal(2);
+      .then(() => Promise.all([
+        counter.count({ eventObj: 'five' }),
+        counter.count({ eventObj: 'two' })
+      ]))
+      .then(([fiveCount, twoCount]) => {
+        expect(fiveCount).to.equal(0);
+        expect(twoCount).to.equal(2);
       });
     });
 
@@ -1788,15 +1443,8 @@ describe('Counter', () => {
         timeGranularity: 'day'
       });
 
-      const start = moment.utc({ year: 2015, day: 1 });
-      const end = moment.utc({ year: 2015, day: 2 });
-      const expectedBefore = {};
-      expectedBefore[start.format()] = 1;
-      expectedBefore[end.format()] = 2;
-
-      const expectedAfter = {};
-      expectedAfter[start.format()] = 0;
-      expectedAfter[end.format()] = 0;
+      const startDate = moment.utc({ year: 2015, day: 1 });
+      const endDate = moment.utc({ year: 2015, day: 2 });
 
       const clock = sandbox.useFakeTimers(new Date('2015-01-01').getTime());
       return counter.incr()
@@ -1804,13 +1452,19 @@ describe('Counter', () => {
           clock.tick(1000 * 60 * 60 * 24);
           return counter.incrby(2);
         })
-        .then(() => counter.countRange('day', start, end))
+        .then(() => counter.countRange('day', { startDate, endDate }))
         .then(result => {
-          expect(result).to.deep.equal(expectedBefore);
+          expect(result).to.deep.equal({
+            [startDate.format()]: 1,
+            [endDate.format()]: 2
+          });
           return counter.zero();
         })
-        .then(() => counter.countRange('day', start, end))
-        .then(result => expect(result).to.deep.equal(expectedAfter));
+        .then(() => counter.countRange('day', { startDate, endDate }))
+        .then(result => expect(result).to.deep.equal({
+          [startDate.format()]: 0,
+          [endDate.format()]: 0
+        }));
     });
   });
 });

--- a/test/counter.js
+++ b/test/counter.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const chai = require('chai'),
+const { expect } = require('chai'),
   sinon = require('sinon'),
   moment = require('moment'),
   IORedis = require('ioredis'),
@@ -9,24 +9,19 @@ const chai = require('chai'),
   constants = require('../lib/constants'),
   utils = require('../lib/utils');
 
-const expect = chai.expect;
-
 describe('Counter', () => {
   let metrics;
   let sandbox;
 
   beforeEach(done => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     const host = process.env.REDIS_HOST || 'localhost';
     const port = process.env.REDIS_PORT || 6379;
     if (process.env.USE_IOREDIS) {
       const client = new IORedis(port, host);
-      metrics = new RedisMetrics({ client: client });
+      metrics = new RedisMetrics({ client });
     } else {
-      metrics = new RedisMetrics({
-        host: host,
-        port: port
-      });
+      metrics = new RedisMetrics({ host, port });
     }
     metrics.client.flushall(done);
   });
@@ -418,7 +413,7 @@ describe('Counter', () => {
       });
 
       return counter.incr('bar').then(result => {
-        expect(parseInt(result)).to.equal(1);
+        expect(Number(result)).to.equal(1);
       });
     });
 
@@ -430,7 +425,7 @@ describe('Counter', () => {
       );
 
       return counter.incr('bar').then(result => {
-        expect(parseInt(result)).to.equal(1);
+        expect(Number(result)).to.equal(1);
       });
     });
 
@@ -617,7 +612,7 @@ describe('Counter', () => {
       const counter = new TimestampedCounter(metrics, 'foo');
 
       counter.incrby(9, 'bar').then(result => {
-        expect(parseInt(result)).to.equal(9);
+        expect(Number(result)).to.equal(9);
         done();
       })
       .catch(done);
@@ -1141,7 +1136,6 @@ describe('Counter', () => {
             counter.incr().then(() => {
               metrics.client.ttl(key, (err2, ttl2) => {
                 // Expect that ttl has decreased.
-                console.log(ttl, ttl2);
                 expect(ttl2).to.be.below(ttl);
                 expect(ttl2).to.be.within(ttl - 2, ttl);
                 done();
@@ -1168,7 +1162,6 @@ describe('Counter', () => {
             counter.incr('bar').then(() => {
               metrics.client.ttl(key, (err2, ttl2) => {
                 // Expect that ttl has decreased.
-                console.log(ttl, ttl2);
                 expect(ttl2).to.be.below(ttl);
                 expect(ttl2).to.be.within(ttl - 2, ttl);
                 done();
@@ -1574,7 +1567,7 @@ describe('Counter', () => {
         counter.incrby(8, 'oranges'),
         counter.incrby(7, 'pears'),
         counter.incrby(5, 'peaches'),
-        counter.incrby(2, 'mangos'),
+        counter.incrby(2, 'mangos')
       ]);
     });
 

--- a/test/metrics.js
+++ b/test/metrics.js
@@ -2,17 +2,15 @@
 
 const redis = require('redis'),
   sinon = require('sinon'),
-  chai = require('chai'),
+  { expect } = require('chai'),
   RedisMetrics = require('../lib/metrics'),
   TimestampedCounter = require('../lib/counter');
 
-const expect = chai.expect;
-
 describe('Metric main', () => {
-
   let sandbox;
+
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
   });
 
   afterEach(() => {
@@ -30,6 +28,8 @@ describe('Metric main', () => {
         .expects('createClient')
         .once()
         .withExactArgs();
+
+      // eslint-disable-next-line no-new
       new RedisMetrics();
       mock.verify();
     });
@@ -39,19 +39,22 @@ describe('Metric main', () => {
         .expects('createClient')
         .once()
         .withExactArgs(1234, 'abcd', {});
+
+      // eslint-disable-next-line no-new
       new RedisMetrics({ host: 'abcd', port: 1234 });
       mock.verify();
     });
 
     it('should create a redis client with options if provided', () => {
-      // jscs:disable requireCamelCaseOrUpperCaseIdentifiers
-      const redisOpts = { no_ready_check: true };
+      const redisOptions = { no_ready_check: true };
 
       const mock = sandbox.mock(redis)
         .expects('createClient')
         .once()
-        .withExactArgs(redisOpts);
-      new RedisMetrics({ redisOptions: redisOpts });
+        .withExactArgs(redisOptions);
+
+      // eslint-disable-next-line no-new
+      new RedisMetrics({ redisOptions });
       mock.verify();
     });
 
@@ -62,7 +65,8 @@ describe('Metric main', () => {
         .expects('createClient')
         .never();
 
-      new RedisMetrics({ client: client });
+      // eslint-disable-next-line no-new
+      new RedisMetrics({ client });
       mock.verify();
     });
   });
@@ -95,5 +99,4 @@ describe('Metric main', () => {
       expect(counter.options.timeGranularity).to.equal(2);
     });
   });
-
 });

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const ensureError = (watchedFn, matcherFn) => {
+  return new Promise((res, rej) => {
+    watchedFn()
+      .then(() => rej(new Error('should have rejected!')))
+      .catch(err => {
+        if (matcherFn) matcherFn(err);
+        res();
+      })
+      .catch(rej);
+  });
+};
+
+module.exports = { ensureError };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1437,11 +1437,7 @@ lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
 
-lodash@^3.10.0:
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
-
-lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0, lodash@^4.8.2:
+lodash@^4.17.10, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0, lodash@^4.8.2:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,21 +2,118 @@
 # yarn lockfile v1
 
 
-JSV@^4.0.x:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/JSV/-/JSV-4.0.2.tgz#d077f6825571f82132f9dffaed587b4029feff57"
+"@babel/code-frame@7.0.0-beta.51":
+  version "7.0.0-beta.51"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0-beta.51.tgz#bd71d9b192af978df915829d39d4094456439a0c"
+  dependencies:
+    "@babel/highlight" "7.0.0-beta.51"
 
-abbrev@1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
+"@babel/generator@7.0.0-beta.51":
+  version "7.0.0-beta.51"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.0.0-beta.51.tgz#6c7575ffde761d07485e04baedc0392c6d9e30f6"
+  dependencies:
+    "@babel/types" "7.0.0-beta.51"
+    jsesc "^2.5.1"
+    lodash "^4.17.5"
+    source-map "^0.5.0"
+    trim-right "^1.0.1"
 
-abbrev@1.0.x:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.0.9.tgz#91b4792588a7738c25f35dd6f63752a2f8776135"
+"@babel/helper-function-name@7.0.0-beta.51":
+  version "7.0.0-beta.51"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.51.tgz#21b4874a227cf99ecafcc30a90302da5a2640561"
+  dependencies:
+    "@babel/helper-get-function-arity" "7.0.0-beta.51"
+    "@babel/template" "7.0.0-beta.51"
+    "@babel/types" "7.0.0-beta.51"
 
-acorn@^5.2.1:
+"@babel/helper-get-function-arity@7.0.0-beta.51":
+  version "7.0.0-beta.51"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.51.tgz#3281b2d045af95c172ce91b20825d85ea4676411"
+  dependencies:
+    "@babel/types" "7.0.0-beta.51"
+
+"@babel/helper-split-export-declaration@7.0.0-beta.51":
+  version "7.0.0-beta.51"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.51.tgz#8a6c3f66c4d265352fc077484f9f6e80a51ab978"
+  dependencies:
+    "@babel/types" "7.0.0-beta.51"
+
+"@babel/highlight@7.0.0-beta.51":
+  version "7.0.0-beta.51"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.0.0-beta.51.tgz#e8844ae25a1595ccfd42b89623b4376ca06d225d"
+  dependencies:
+    chalk "^2.0.0"
+    esutils "^2.0.2"
+    js-tokens "^3.0.0"
+
+"@babel/parser@7.0.0-beta.51":
+  version "7.0.0-beta.51"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.0.0-beta.51.tgz#27cec2df409df60af58270ed8f6aa55409ea86f6"
+
+"@babel/template@7.0.0-beta.51":
+  version "7.0.0-beta.51"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.0.0-beta.51.tgz#9602a40aebcf357ae9677e2532ef5fc810f5fbff"
+  dependencies:
+    "@babel/code-frame" "7.0.0-beta.51"
+    "@babel/parser" "7.0.0-beta.51"
+    "@babel/types" "7.0.0-beta.51"
+    lodash "^4.17.5"
+
+"@babel/traverse@7.0.0-beta.51":
+  version "7.0.0-beta.51"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.0.0-beta.51.tgz#981daf2cec347a6231d3aa1d9e1803b03aaaa4a8"
+  dependencies:
+    "@babel/code-frame" "7.0.0-beta.51"
+    "@babel/generator" "7.0.0-beta.51"
+    "@babel/helper-function-name" "7.0.0-beta.51"
+    "@babel/helper-split-export-declaration" "7.0.0-beta.51"
+    "@babel/parser" "7.0.0-beta.51"
+    "@babel/types" "7.0.0-beta.51"
+    debug "^3.1.0"
+    globals "^11.1.0"
+    invariant "^2.2.0"
+    lodash "^4.17.5"
+
+"@babel/types@7.0.0-beta.51":
+  version "7.0.0-beta.51"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.0.0-beta.51.tgz#d802b7b543b5836c778aa691797abf00f3d97ea9"
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.17.5"
+    to-fast-properties "^2.0.0"
+
+"@sinonjs/formatio@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/formatio/-/formatio-2.0.0.tgz#84db7e9eb5531df18a8c5e0bfb6e449e55e654b2"
+  dependencies:
+    samsam "1.3.0"
+
+"@sinonjs/samsam@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-2.0.0.tgz#9163742ac35c12d3602dece74317643b35db6a80"
+
+acorn-jsx@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-4.1.1.tgz#e8e41e48ea2fe0c896740610ab6a4ffd8add225e"
+  dependencies:
+    acorn "^5.0.3"
+
+acorn@^5.0.3, acorn@^5.6.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.1.tgz#f095829297706a7c9776958c0afc8930a9b9d9d8"
+
+ajv-keywords@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.2.0.tgz#e86b819c602cf8821ad637413698f1dec021847a"
+
+ajv@^6.0.1, ajv@^6.5.0:
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.5.2.tgz#678495f9b82f7cca6be248dd92f59bff5e1f4360"
+  dependencies:
+    fast-deep-equal "^2.0.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.1"
 
 align-text@^0.1.1, align-text@^0.1.3:
   version "0.1.4"
@@ -26,226 +123,199 @@ align-text@^0.1.1, align-text@^0.1.3:
     longest "^1.0.1"
     repeat-string "^1.5.2"
 
-alter@~0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/alter/-/alter-0.2.0.tgz#c7588808617572034aae62480af26b1d4d1cb3cd"
-  dependencies:
-    stable "~0.1.3"
-
 amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
+
+ansi-escapes@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.1.0.tgz#f73207bb81207d75fd6c83f125af26eea378ca30"
 
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
 
+ansi-regex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
+
 ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
-ansi-styles@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-1.0.0.tgz#cb102df1c56f5123eab8b67cd7b98027a0279178"
+ansi-styles@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
+  dependencies:
+    color-convert "^1.9.0"
 
-argparse@^1.0.2, argparse@^1.0.7:
+append-transform@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/append-transform/-/append-transform-0.4.0.tgz#d76ebf8ca94d276e247a36bad44a4b74ab611991"
+  dependencies:
+    default-require-extensions "^1.0.0"
+
+archy@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/archy/-/archy-1.0.0.tgz#f9c8c13757cc1dd7bc379ac77b2c62a5c2868c40"
+
+argparse@^1.0.7:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
   dependencies:
     sprintf-js "~1.0.2"
 
+arr-diff@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-4.0.0.tgz#d6461074febfec71e7e15235761a329a5dc7c520"
+
+arr-flatten@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/arr-flatten/-/arr-flatten-1.1.0.tgz#36048bbff4e7b47e136644316c99669ea5ae91f1"
+
+arr-union@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
+
+array-union@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/array-union/-/array-union-1.0.2.tgz#9a34410e4f4e3da23dea375be5be70f24778ec39"
+  dependencies:
+    array-uniq "^1.0.1"
+
+array-uniq@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
+
+array-unique@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
+
+arrify@^1.0.0, arrify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
+
 assertion-error@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
 
-ast-traverse@~0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/ast-traverse/-/ast-traverse-0.1.1.tgz#69cf2b8386f19dcda1bb1e05d68fe359d8897de6"
-
-ast-types@0.8.12:
-  version "0.8.12"
-  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.8.12.tgz#a0d90e4351bb887716c83fd637ebf818af4adfcc"
-
-ast-types@0.8.15:
-  version "0.8.15"
-  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.8.15.tgz#8eef0827f04dff0ec8857ba925abe3fea6194e52"
-
-ast-types@0.9.6:
-  version "0.9.6"
-  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.6.tgz#102c9e9e9005d3e7e3829bf0c4fa24ee862ee9b9"
-
-async@0.2.x, async@~0.2.9:
-  version "0.2.10"
-  resolved "https://registry.yarnpkg.com/async/-/async-0.2.10.tgz#b6bbe0b0674b9d719708ca38de8c237cb526c3d1"
-
-async@1.x, async@^1.4.0:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
+assign-symbols@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
 
 async@^0.9.0:
   version "0.9.2"
   resolved "https://registry.yarnpkg.com/async/-/async-0.9.2.tgz#aea74d5e61c1f899613bf64bda66d4c78f2fd17d"
 
-babel-core@~5.8.3:
-  version "5.8.38"
-  resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-5.8.38.tgz#1fcaee79d7e61b750b00b8e54f6dfc9d0af86558"
+async@^1.4.0:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
+
+atob@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.1.tgz#ae2d5a729477f289d60dd7f96a6314a22dd6c22a"
+
+babel-code-frame@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
   dependencies:
-    babel-plugin-constant-folding "^1.0.1"
-    babel-plugin-dead-code-elimination "^1.0.2"
-    babel-plugin-eval "^1.0.1"
-    babel-plugin-inline-environment-variables "^1.0.1"
-    babel-plugin-jscript "^1.0.4"
-    babel-plugin-member-expression-literals "^1.0.1"
-    babel-plugin-property-literals "^1.0.1"
-    babel-plugin-proto-to-assign "^1.0.3"
-    babel-plugin-react-constant-elements "^1.0.3"
-    babel-plugin-react-display-name "^1.0.3"
-    babel-plugin-remove-console "^1.0.1"
-    babel-plugin-remove-debugger "^1.0.1"
-    babel-plugin-runtime "^1.0.7"
-    babel-plugin-undeclared-variables-check "^1.0.2"
-    babel-plugin-undefined-to-void "^1.1.6"
-    babylon "^5.8.38"
-    bluebird "^2.9.33"
-    chalk "^1.0.0"
-    convert-source-map "^1.1.0"
-    core-js "^1.0.0"
-    debug "^2.1.1"
-    detect-indent "^3.0.0"
-    esutils "^2.0.0"
-    fs-readdir-recursive "^0.1.0"
-    globals "^6.4.0"
-    home-or-tmp "^1.0.0"
-    is-integer "^1.0.4"
-    js-tokens "1.0.1"
-    json5 "^0.4.0"
-    lodash "^3.10.0"
-    minimatch "^2.0.3"
-    output-file-sync "^1.1.0"
-    path-exists "^1.0.0"
-    path-is-absolute "^1.0.0"
-    private "^0.1.6"
-    regenerator "0.8.40"
-    regexpu "^1.3.0"
-    repeating "^1.1.2"
-    resolve "^1.1.6"
-    shebang-regex "^1.0.0"
-    slash "^1.0.0"
-    source-map "^0.5.0"
-    source-map-support "^0.2.10"
-    to-fast-properties "^1.0.0"
-    trim-right "^1.0.0"
-    try-resolve "^1.0.0"
-
-babel-jscs@^2.0.0:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/babel-jscs/-/babel-jscs-2.0.5.tgz#0a347046b48145acbca56e8c8ed5f736bc54f9d0"
-  dependencies:
-    babel-core "~5.8.3"
-    lodash.assign "^3.2.0"
-
-babel-plugin-constant-folding@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-constant-folding/-/babel-plugin-constant-folding-1.0.1.tgz#8361d364c98e449c3692bdba51eff0844290aa8e"
-
-babel-plugin-dead-code-elimination@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/babel-plugin-dead-code-elimination/-/babel-plugin-dead-code-elimination-1.0.2.tgz#5f7c451274dcd7cccdbfbb3e0b85dd28121f0f65"
-
-babel-plugin-eval@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-eval/-/babel-plugin-eval-1.0.1.tgz#a2faed25ce6be69ade4bfec263f70169195950da"
-
-babel-plugin-inline-environment-variables@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-inline-environment-variables/-/babel-plugin-inline-environment-variables-1.0.1.tgz#1f58ce91207ad6a826a8bf645fafe68ff5fe3ffe"
-
-babel-plugin-jscript@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/babel-plugin-jscript/-/babel-plugin-jscript-1.0.4.tgz#8f342c38276e87a47d5fa0a8bd3d5eb6ccad8fcc"
-
-babel-plugin-member-expression-literals@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-member-expression-literals/-/babel-plugin-member-expression-literals-1.0.1.tgz#cc5edb0faa8dc927170e74d6d1c02440021624d3"
-
-babel-plugin-property-literals@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-property-literals/-/babel-plugin-property-literals-1.0.1.tgz#0252301900192980b1c118efea48ce93aab83336"
-
-babel-plugin-proto-to-assign@^1.0.3:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/babel-plugin-proto-to-assign/-/babel-plugin-proto-to-assign-1.0.4.tgz#c49e7afd02f577bc4da05ea2df002250cf7cd123"
-  dependencies:
-    lodash "^3.9.3"
-
-babel-plugin-react-constant-elements@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/babel-plugin-react-constant-elements/-/babel-plugin-react-constant-elements-1.0.3.tgz#946736e8378429cbc349dcff62f51c143b34e35a"
-
-babel-plugin-react-display-name@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/babel-plugin-react-display-name/-/babel-plugin-react-display-name-1.0.3.tgz#754fe38926e8424a4e7b15ab6ea6139dee0514fc"
-
-babel-plugin-remove-console@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-remove-console/-/babel-plugin-remove-console-1.0.1.tgz#d8f24556c3a05005d42aaaafd27787f53ff013a7"
-
-babel-plugin-remove-debugger@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-remove-debugger/-/babel-plugin-remove-debugger-1.0.1.tgz#fd2ea3cd61a428ad1f3b9c89882ff4293e8c14c7"
-
-babel-plugin-runtime@^1.0.7:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/babel-plugin-runtime/-/babel-plugin-runtime-1.0.7.tgz#bf7c7d966dd56ecd5c17fa1cb253c9acb7e54aaf"
-
-babel-plugin-undeclared-variables-check@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/babel-plugin-undeclared-variables-check/-/babel-plugin-undeclared-variables-check-1.0.2.tgz#5cf1aa539d813ff64e99641290af620965f65dee"
-  dependencies:
-    leven "^1.0.2"
-
-babel-plugin-undefined-to-void@^1.1.6:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/babel-plugin-undefined-to-void/-/babel-plugin-undefined-to-void-1.1.6.tgz#7f578ef8b78dfae6003385d8417a61eda06e2f81"
+    chalk "^1.1.3"
+    esutils "^2.0.2"
+    js-tokens "^3.0.2"
 
 babylon@7.0.0-beta.19:
   version "7.0.0-beta.19"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.19.tgz#e928c7e807e970e0536b078ab3e0c48f9e052503"
 
-babylon@^5.8.38:
-  version "5.8.38"
-  resolved "https://registry.yarnpkg.com/babylon/-/babylon-5.8.38.tgz#ec9b120b11bf6ccd4173a18bf217e60b79859ffd"
-
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
 
-bluebird@^2.9.33:
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-2.11.0.tgz#534b9033c022c9579c56ba3b3e5a5caafbb650e1"
+base@^0.11.1:
+  version "0.11.2"
+  resolved "https://registry.yarnpkg.com/base/-/base-0.11.2.tgz#7bde5ced145b6d551a90db87f83c558b4eb48a8f"
+  dependencies:
+    cache-base "^1.0.1"
+    class-utils "^0.3.5"
+    component-emitter "^1.2.1"
+    define-property "^1.0.0"
+    isobject "^3.0.1"
+    mixin-deep "^1.2.0"
+    pascalcase "^0.1.1"
 
 bluebird@^3.3.4, bluebird@~3.5.0:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
 
-brace-expansion@^1.0.0, brace-expansion@^1.1.7:
+brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-breakable@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/breakable/-/breakable-1.0.0.tgz#784a797915a38ead27bad456b5572cb4bbaa78c1"
+braces@^2.3.1:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/braces/-/braces-2.3.2.tgz#5979fd3f14cd531565e5fa2df1abfff1dfaee729"
+  dependencies:
+    arr-flatten "^1.1.0"
+    array-unique "^0.3.2"
+    extend-shallow "^2.0.1"
+    fill-range "^4.0.0"
+    isobject "^3.0.1"
+    repeat-element "^1.1.2"
+    snapdragon "^0.8.1"
+    snapdragon-node "^2.0.1"
+    split-string "^3.0.2"
+    to-regex "^3.0.1"
 
-browser-stdout@1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.0.tgz#f351d32969d32fa5d7a5567154263d928ae3bd1f"
+browser-stdout@1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz#baa559ee14ced73452229bad7326467c61fabd60"
 
-camelcase@^1.0.2, camelcase@^1.2.1:
+builtin-modules@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
+
+cache-base@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/cache-base/-/cache-base-1.0.1.tgz#0a7f46416831c8b662ee36fe4e7c59d76f666ab2"
+  dependencies:
+    collection-visit "^1.0.0"
+    component-emitter "^1.2.1"
+    get-value "^2.0.6"
+    has-value "^1.0.0"
+    isobject "^3.0.1"
+    set-value "^2.0.0"
+    to-object-path "^0.3.0"
+    union-value "^1.0.0"
+    unset-value "^1.0.0"
+
+caching-transform@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/caching-transform/-/caching-transform-1.0.1.tgz#6dbdb2f20f8d8fbce79f3e94e9d1742dcdf5c0a1"
+  dependencies:
+    md5-hex "^1.2.0"
+    mkdirp "^0.5.1"
+    write-file-atomic "^1.1.4"
+
+caller-path@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-0.1.0.tgz#94085ef63581ecd3daa92444a8fe94e82577751f"
+  dependencies:
+    callsites "^0.2.0"
+
+callsites@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/callsites/-/callsites-0.2.0.tgz#afab96262910a7f33c19a5775825c69f34e350ca"
+
+camelcase@^1.0.2:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-1.2.1.tgz#9bb5304d2e0b56698b2c758b08a3eaa9daa58a39"
+
+camelcase@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
 
 catharsis@~0.8.9:
   version "0.8.9"
@@ -271,7 +341,7 @@ chai@^4.1.1:
     pathval "^1.0.0"
     type-detect "^4.0.0"
 
-chalk@^1.0.0, chalk@~1.1.0:
+chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   dependencies:
@@ -281,30 +351,44 @@ chalk@^1.0.0, chalk@~1.1.0:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@~0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-0.4.0.tgz#5199a3ddcd0c1efe23bc08c1b027b06176e0c64f"
+chalk@^2.0.0, chalk@^2.1.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
   dependencies:
-    ansi-styles "~1.0.0"
-    has-color "~0.1.0"
-    strip-ansi "~0.1.0"
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
+
+chardet@^0.4.0:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
 
 check-error@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
 
-cli-table@~0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/cli-table/-/cli-table-0.3.1.tgz#f53b05266a8b1a0b934b3d0821e6e2dc5914ae23"
-  dependencies:
-    colors "1.0.3"
+circular-json@^0.3.1:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.3.tgz#815c99ea84f6809529d2f45791bdf82711352d66"
 
-cli@~1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/cli/-/cli-1.0.1.tgz#22817534f24bfa4950c34d532d48ecbc621b8c14"
+class-utils@^0.3.5:
+  version "0.3.6"
+  resolved "https://registry.yarnpkg.com/class-utils/-/class-utils-0.3.6.tgz#f93369ae8b9a7ce02fd41faad0ca83033190c463"
   dependencies:
-    exit "0.1.2"
-    glob "^7.1.1"
+    arr-union "^3.1.0"
+    define-property "^0.2.5"
+    isobject "^3.0.0"
+    static-extend "^0.1.1"
+
+cli-cursor@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
+  dependencies:
+    restore-cursor "^2.0.0"
+
+cli-width@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
 
 cliui@^2.1.0:
   version "2.1.0"
@@ -314,99 +398,115 @@ cliui@^2.1.0:
     right-align "^0.1.1"
     wordwrap "0.0.2"
 
+cliui@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-4.1.0.tgz#348422dbe82d800b3022eef4f6ac10bf2e4d1b49"
+  dependencies:
+    string-width "^2.1.1"
+    strip-ansi "^4.0.0"
+    wrap-ansi "^2.0.0"
+
 cluster-key-slot@^1.0.6:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/cluster-key-slot/-/cluster-key-slot-1.0.12.tgz#d5deff2a520717bc98313979b687309b2d368e29"
 
-colors@0.6.x:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/colors/-/colors-0.6.2.tgz#2423fe6678ac0c5dae8852e5d0e5be08c997abcc"
+code-point-at@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
-colors@1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
-
-commander@2.9.0, commander@~2.9.0:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
+collection-visit@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/collection-visit/-/collection-visit-1.0.0.tgz#4bc0373c164bc3291b4d368c829cf1a80a59dca0"
   dependencies:
-    graceful-readlink ">= 1.0.0"
+    map-visit "^1.0.0"
+    object-visit "^1.0.0"
 
-commander@^2.5.0:
-  version "2.16.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.16.0.tgz#f16390593996ceb4f3eeb020b31d78528f7f8a50"
-
-comment-parser@^0.3.1:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/comment-parser/-/comment-parser-0.3.2.tgz#3c03f0776b86a36dfd9a0a2c97c6307f332082fe"
+color-convert@^1.9.0:
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.2.tgz#49881b8fba67df12a96bdf3f56c0aab9e7913147"
   dependencies:
-    readable-stream "^2.0.4"
+    color-name "1.1.1"
 
-commoner@~0.10.3:
-  version "0.10.8"
-  resolved "https://registry.yarnpkg.com/commoner/-/commoner-0.10.8.tgz#34fc3672cd24393e8bb47e70caa0293811f4f2c5"
-  dependencies:
-    commander "^2.5.0"
-    detective "^4.3.1"
-    glob "^5.0.15"
-    graceful-fs "^4.1.2"
-    iconv-lite "^0.4.5"
-    mkdirp "^0.5.0"
-    private "^0.1.6"
-    q "^1.1.2"
-    recast "^0.11.17"
+color-name@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.1.tgz#4b1415304cf50028ea81643643bd82ea05803689"
+
+commander@2.15.1:
+  version "2.15.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
+
+commondir@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
+
+component-emitter@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
 
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-console-browserify@1.1.x:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/console-browserify/-/console-browserify-1.1.0.tgz#f0241c45730a9fc6323b206dbf38edc741d0bb10"
-  dependencies:
-    date-now "^0.1.4"
+contains-path@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/contains-path/-/contains-path-0.1.0.tgz#fe8cf184ff6670b6baef01a9d4861a5cbec4120a"
 
-convert-source-map@^1.1.0:
+convert-source-map@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.1.tgz#b8278097b9bc229365de5c62cf5fcaed8b5599e5"
 
-core-js@^1.0.0:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
+copy-descriptor@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
 
-core-util-is@~1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
-
-cycle@1.0.x:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/cycle/-/cycle-1.0.3.tgz#21e80b2be8580f98b468f379430662b046c34ad2"
-
-d@1:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/d/-/d-1.0.0.tgz#754bb5bfe55451da69a58b94d45f4c5b0462d58f"
+cross-spawn@^4:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-4.0.2.tgz#7b9247621c23adfdd3856004a823cbe397424d41"
   dependencies:
-    es5-ext "^0.10.9"
+    lru-cache "^4.0.1"
+    which "^1.2.9"
 
-date-now@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
+cross-spawn@^5.0.1:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
+  dependencies:
+    lru-cache "^4.0.1"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
 
-debug@2.6.8:
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
+cross-spawn@^6.0.5:
+  version "6.0.5"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
+  dependencies:
+    nice-try "^1.0.4"
+    path-key "^2.0.1"
+    semver "^5.5.0"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
+
+debug-log@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/debug-log/-/debug-log-1.0.1.tgz#2307632d4c04382b8df8a32f70b895046d52745f"
+
+debug@3.1.0, debug@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   dependencies:
     ms "2.0.0"
 
-debug@^2.1.1, debug@^2.2.0:
+debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
     ms "2.0.0"
 
-decamelize@^1.0.0:
+decamelize@^1.0.0, decamelize@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
+
+decode-uri-component@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
 
 deep-eql@^3.0.0:
   version "3.0.1"
@@ -414,192 +514,230 @@ deep-eql@^3.0.0:
   dependencies:
     type-detect "^4.0.0"
 
-deep-equal@*:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
-
-deep-is@~0.1.2:
+deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
 
-defined@^1.0.0:
+default-require-extensions@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/defined/-/defined-1.0.0.tgz#c98d9bcef75674188e110969151199e39b1fa693"
-
-defs@~1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/defs/-/defs-1.1.1.tgz#b22609f2c7a11ba7a3db116805c139b1caffa9d2"
+  resolved "https://registry.yarnpkg.com/default-require-extensions/-/default-require-extensions-1.0.0.tgz#f37ea15d3e13ffd9b437d33e1a75b5fb97874cb8"
   dependencies:
-    alter "~0.2.0"
-    ast-traverse "~0.1.1"
-    breakable "~1.0.0"
-    esprima-fb "~15001.1001.0-dev-harmony-fb"
-    simple-fmt "~0.1.0"
-    simple-is "~0.2.0"
-    stringmap "~0.2.2"
-    stringset "~0.2.1"
-    tryor "~0.1.2"
-    yargs "~3.27.0"
+    strip-bom "^2.0.0"
 
-detect-indent@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-3.0.1.tgz#9dc5e5ddbceef8325764b9451b02bc6d54084f75"
+define-properties@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.2.tgz#83a73f2fea569898fb737193c8f873caf6d45c94"
   dependencies:
-    get-stdin "^4.0.1"
-    minimist "^1.1.0"
-    repeating "^1.1.0"
+    foreach "^2.0.5"
+    object-keys "^1.0.8"
 
-detective@^4.3.1:
-  version "4.7.1"
-  resolved "https://registry.yarnpkg.com/detective/-/detective-4.7.1.tgz#0eca7314338442febb6d65da54c10bb1c82b246e"
+define-property@^0.2.5:
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/define-property/-/define-property-0.2.5.tgz#c35b1ef918ec3c990f9a5bc57be04aacec5c8116"
   dependencies:
-    acorn "^5.2.1"
-    defined "^1.0.0"
+    is-descriptor "^0.1.0"
 
-diff@3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
-
-dom-serializer@0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.0.tgz#073c697546ce0780ce23be4a28e293e40bc30c82"
+define-property@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/define-property/-/define-property-1.0.0.tgz#769ebaaf3f4a63aad3af9e8d304c9bbe79bfb0e6"
   dependencies:
-    domelementtype "~1.1.1"
-    entities "~1.1.1"
+    is-descriptor "^1.0.0"
 
-domelementtype@1:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.0.tgz#b17aed82e8ab59e52dd9c19b1756e0fc187204c2"
-
-domelementtype@~1.1.1:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.1.3.tgz#bd28773e2642881aec51544924299c5cd822185b"
-
-domhandler@2.3:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.3.0.tgz#2de59a0822d5027fabff6f032c2b25a2a8abe738"
+define-property@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/define-property/-/define-property-2.0.2.tgz#d459689e8d654ba77e02a817f8710d702cb16e9d"
   dependencies:
-    domelementtype "1"
+    is-descriptor "^1.0.2"
+    isobject "^3.0.1"
 
-domutils@1.5:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"
+del@^2.0.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/del/-/del-2.2.2.tgz#c12c981d067846c84bcaf862cff930d907ffd1a8"
   dependencies:
-    dom-serializer "0"
-    domelementtype "1"
+    globby "^5.0.0"
+    is-path-cwd "^1.0.0"
+    is-path-in-cwd "^1.0.0"
+    object-assign "^4.0.1"
+    pify "^2.0.0"
+    pinkie-promise "^2.0.0"
+    rimraf "^2.2.8"
+
+diff@3.5.0, diff@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
+
+doctrine@1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa"
+  dependencies:
+    esutils "^2.0.2"
+    isarray "^1.0.0"
+
+doctrine@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
+  dependencies:
+    esutils "^2.0.2"
 
 double-ended-queue@^2.1.0-0:
   version "2.1.0-0"
   resolved "https://registry.yarnpkg.com/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz#103d3527fd31528f40188130c841efdd78264e5c"
 
-entities@1.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/entities/-/entities-1.0.0.tgz#b2987aa3821347fcde642b24fdfc9e4fb712bf26"
+error-ex@^1.2.0:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.2.tgz#b4ac40648107fdcdcfae242f428bea8a14d4f1bf"
+  dependencies:
+    is-arrayish "^0.2.1"
 
-entities@~1.1.1:
+es-abstract@^1.10.0:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.12.0.tgz#9dbbdd27c6856f0001421ca18782d786bf8a6165"
+  dependencies:
+    es-to-primitive "^1.1.1"
+    function-bind "^1.1.1"
+    has "^1.0.1"
+    is-callable "^1.1.3"
+    is-regex "^1.0.4"
+
+es-to-primitive@^1.1.1:
   version "1.1.1"
-  resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
-
-es5-ext@^0.10.14, es5-ext@^0.10.35, es5-ext@^0.10.9, es5-ext@~0.10.14:
-  version "0.10.45"
-  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.45.tgz#0bfdf7b473da5919d5adf3bd25ceb754fccc3653"
+  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.1.1.tgz#45355248a88979034b6792e19bb81f2b7975dd0d"
   dependencies:
-    es6-iterator "~2.0.3"
-    es6-symbol "~3.1.1"
-    next-tick "1"
+    is-callable "^1.1.1"
+    is-date-object "^1.0.1"
+    is-symbol "^1.0.1"
 
-es6-iterator@^2.0.1, es6-iterator@~2.0.1, es6-iterator@~2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.3.tgz#a7de889141a05a94b0854403b2d0a0fbfa98f3b7"
-  dependencies:
-    d "1"
-    es5-ext "^0.10.35"
-    es6-symbol "^3.1.1"
-
-es6-map@^0.1.3:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/es6-map/-/es6-map-0.1.5.tgz#9136e0503dcc06a301690f0bb14ff4e364e949f0"
-  dependencies:
-    d "1"
-    es5-ext "~0.10.14"
-    es6-iterator "~2.0.1"
-    es6-set "~0.1.5"
-    es6-symbol "~3.1.1"
-    event-emitter "~0.3.5"
-
-es6-set@~0.1.5:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/es6-set/-/es6-set-0.1.5.tgz#d2b3ec5d4d800ced818db538d28974db0a73ccb1"
-  dependencies:
-    d "1"
-    es5-ext "~0.10.14"
-    es6-iterator "~2.0.1"
-    es6-symbol "3.1.1"
-    event-emitter "~0.3.5"
-
-es6-symbol@3.1.1, es6-symbol@^3.1.1, es6-symbol@~3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.1.tgz#bf00ef4fdab6ba1b46ecb7b629b4c7ed5715cc77"
-  dependencies:
-    d "1"
-    es5-ext "~0.10.14"
-
-es6-weak-map@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/es6-weak-map/-/es6-weak-map-2.0.2.tgz#5e3ab32251ffd1538a1f8e5ffa1357772f92d96f"
-  dependencies:
-    d "1"
-    es5-ext "^0.10.14"
-    es6-iterator "^2.0.1"
-    es6-symbol "^3.1.1"
-
-escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@~1.0.5:
+escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5, escape-string-regexp@~1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
-escodegen@1.7.x:
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.7.1.tgz#30ecfcf66ca98dc67cd2fd162abeb6eafa8ce6fc"
+eslint-config-airbnb-base@^12.1.0:
+  version "12.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-airbnb-base/-/eslint-config-airbnb-base-12.1.0.tgz#386441e54a12ccd957b0a92564a4bafebd747944"
   dependencies:
-    esprima "^1.2.2"
-    estraverse "^1.9.1"
-    esutils "^2.0.2"
-    optionator "^0.5.0"
-  optionalDependencies:
-    source-map "~0.2.0"
+    eslint-restricted-globals "^0.1.1"
 
-escope@^3.2.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/escope/-/escope-3.6.0.tgz#e01975e812781a163a6dadfdd80398dc64c889c3"
+eslint-config-conversio@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-conversio/-/eslint-config-conversio-2.2.0.tgz#a4cc7277a89274cee2fa24ef8a9a8f50162c3af2"
   dependencies:
-    es6-map "^0.1.3"
-    es6-weak-map "^2.0.1"
+    eslint-config-airbnb-base "^12.1.0"
+    eslint-plugin-import "^2.8.0"
+
+eslint-import-resolver-node@^0.3.1:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz#58f15fb839b8d0576ca980413476aab2472db66a"
+  dependencies:
+    debug "^2.6.9"
+    resolve "^1.5.0"
+
+eslint-module-utils@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.2.0.tgz#b270362cd88b1a48ad308976ce7fa54e98411746"
+  dependencies:
+    debug "^2.6.8"
+    pkg-dir "^1.0.0"
+
+eslint-plugin-import@^2.8.0:
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.13.0.tgz#df24f241175e312d91662dc91ca84064caec14ed"
+  dependencies:
+    contains-path "^0.1.0"
+    debug "^2.6.8"
+    doctrine "1.5.0"
+    eslint-import-resolver-node "^0.3.1"
+    eslint-module-utils "^2.2.0"
+    has "^1.0.1"
+    lodash "^4.17.4"
+    minimatch "^3.0.3"
+    read-pkg-up "^2.0.0"
+    resolve "^1.6.0"
+
+eslint-plugin-mocha@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-mocha/-/eslint-plugin-mocha-5.1.0.tgz#3637cdde93155e650591d7ab14e7a66485f0f7c1"
+  dependencies:
+    ramda "^0.25.0"
+
+eslint-restricted-globals@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-restricted-globals/-/eslint-restricted-globals-0.1.1.tgz#35f0d5cbc64c2e3ed62e93b4b1a7af05ba7ed4d7"
+
+eslint-scope@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.0.tgz#50bf3071e9338bcdc43331794a0cb533f0136172"
+  dependencies:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-esprima-fb@~15001.1001.0-dev-harmony-fb:
-  version "15001.1001.0-dev-harmony-fb"
-  resolved "https://registry.yarnpkg.com/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz#43beb57ec26e8cf237d3dd8b33e42533577f2659"
+eslint-utils@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.3.1.tgz#9a851ba89ee7c460346f97cf8939c7298827e512"
 
-esprima@2.5.x:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/esprima/-/esprima-2.5.0.tgz#f387a46fd344c1b1a39baf8c20bfb43b6d0058cc"
+eslint-visitor-keys@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
 
-esprima@^1.2.2:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/esprima/-/esprima-1.2.5.tgz#0993502feaf668138325756f30f9a51feeec11e9"
+eslint@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-5.2.0.tgz#3901ae249195d473e633c4acbc370068b1c964dc"
+  dependencies:
+    ajv "^6.5.0"
+    babel-code-frame "^6.26.0"
+    chalk "^2.1.0"
+    cross-spawn "^6.0.5"
+    debug "^3.1.0"
+    doctrine "^2.1.0"
+    eslint-scope "^4.0.0"
+    eslint-utils "^1.3.1"
+    eslint-visitor-keys "^1.0.0"
+    espree "^4.0.0"
+    esquery "^1.0.1"
+    esutils "^2.0.2"
+    file-entry-cache "^2.0.0"
+    functional-red-black-tree "^1.0.1"
+    glob "^7.1.2"
+    globals "^11.7.0"
+    ignore "^4.0.2"
+    imurmurhash "^0.1.4"
+    inquirer "^5.2.0"
+    is-resolvable "^1.1.0"
+    js-yaml "^3.11.0"
+    json-stable-stringify-without-jsonify "^1.0.1"
+    levn "^0.3.0"
+    lodash "^4.17.5"
+    minimatch "^3.0.4"
+    mkdirp "^0.5.1"
+    natural-compare "^1.4.0"
+    optionator "^0.8.2"
+    path-is-inside "^1.0.2"
+    pluralize "^7.0.0"
+    progress "^2.0.0"
+    regexpp "^1.1.0"
+    require-uncached "^1.0.3"
+    semver "^5.5.0"
+    string.prototype.matchall "^2.0.0"
+    strip-ansi "^4.0.0"
+    strip-json-comments "^2.0.1"
+    table "^4.0.3"
+    text-table "^0.2.0"
 
-esprima@^2.6.0, esprima@~2.7.0:
-  version "2.7.3"
-  resolved "https://registry.yarnpkg.com/esprima/-/esprima-2.7.3.tgz#96e3b70d5779f6ad49cd032673d1c312767ba581"
+espree@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-4.0.0.tgz#253998f20a0f82db5d866385799d912a83a36634"
+  dependencies:
+    acorn "^5.6.0"
+    acorn-jsx "^4.1.1"
 
 esprima@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
 
-esprima@~3.1.0:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
+esquery@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.0.1.tgz#406c51658b1f5991a5f9b62b1dc25b00e3e5c708"
+  dependencies:
+    estraverse "^4.0.0"
 
 esrecurse@^4.1.0:
   version "4.2.1"
@@ -607,92 +745,190 @@ esrecurse@^4.1.0:
   dependencies:
     estraverse "^4.1.0"
 
-estraverse@^1.9.1:
-  version "1.9.3"
-  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-1.9.3.tgz#af67f2dc922582415950926091a4005d29c9bb44"
-
-estraverse@^4.1.0, estraverse@^4.1.1:
+estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
 
-esutils@^2.0.0, esutils@^2.0.2:
+esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
 
-event-emitter@~0.3.5:
-  version "0.3.5"
-  resolved "https://registry.yarnpkg.com/event-emitter/-/event-emitter-0.3.5.tgz#df8c69eef1647923c7157b9ce83840610b02cc39"
+execa@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.7.0.tgz#944becd34cc41ee32a63a9faf27ad5a65fc59777"
   dependencies:
-    d "1"
-    es5-ext "~0.10.14"
+    cross-spawn "^5.0.1"
+    get-stream "^3.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
 
-exit@0.1.2, exit@0.1.x, exit@~0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
-
-eyes@0.1.x:
-  version "0.1.8"
-  resolved "https://registry.yarnpkg.com/eyes/-/eyes-0.1.8.tgz#62cf120234c683785d902348a800ef3e0cc20bc0"
-
-fast-levenshtein@~1.0.0:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz#0178dcdee023b92905193af0959e8a7639cfdcb9"
-
-fileset@0.2.x:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/fileset/-/fileset-0.2.1.tgz#588ef8973c6623b2a76df465105696b96aac8067"
+expand-brackets@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/expand-brackets/-/expand-brackets-2.1.4.tgz#b77735e315ce30f6b6eff0f83b04151a22449622"
   dependencies:
-    glob "5.x"
-    minimatch "2.x"
+    debug "^2.3.3"
+    define-property "^0.2.5"
+    extend-shallow "^2.0.1"
+    posix-character-classes "^0.1.0"
+    regex-not "^1.0.0"
+    snapdragon "^0.8.1"
+    to-regex "^3.0.1"
+
+extend-shallow@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-2.0.1.tgz#51af7d614ad9a9f610ea1bafbb989d6b1c56890f"
+  dependencies:
+    is-extendable "^0.1.0"
+
+extend-shallow@^3.0.0, extend-shallow@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-3.0.2.tgz#26a71aaf073b39fb2127172746131c2704028db8"
+  dependencies:
+    assign-symbols "^1.0.0"
+    is-extendable "^1.0.1"
+
+external-editor@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.2.0.tgz#045511cfd8d133f3846673d1047c154e214ad3d5"
+  dependencies:
+    chardet "^0.4.0"
+    iconv-lite "^0.4.17"
+    tmp "^0.0.33"
+
+extglob@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/extglob/-/extglob-2.0.4.tgz#ad00fe4dc612a9232e8718711dc5cb5ab0285543"
+  dependencies:
+    array-unique "^0.3.2"
+    define-property "^1.0.0"
+    expand-brackets "^2.1.4"
+    extend-shallow "^2.0.1"
+    fragment-cache "^0.2.1"
+    regex-not "^1.0.0"
+    snapdragon "^0.8.1"
+    to-regex "^3.0.1"
+
+fast-deep-equal@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
+
+fast-json-stable-stringify@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
+
+fast-levenshtein@~2.0.4:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
+
+figures@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
+  dependencies:
+    escape-string-regexp "^1.0.5"
+
+file-entry-cache@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-2.0.0.tgz#c392990c3e684783d838b8c84a45d8a048458361"
+  dependencies:
+    flat-cache "^1.2.1"
+    object-assign "^4.0.1"
+
+fill-range@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-4.0.0.tgz#d544811d428f98eb06a63dc402d2403c328c38f7"
+  dependencies:
+    extend-shallow "^2.0.1"
+    is-number "^3.0.0"
+    repeat-string "^1.6.1"
+    to-regex-range "^2.1.0"
+
+find-cache-dir@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-0.1.1.tgz#c8defae57c8a52a8a784f9e31c57c742e993a0b9"
+  dependencies:
+    commondir "^1.0.1"
+    mkdirp "^0.5.1"
+    pkg-dir "^1.0.0"
+
+find-up@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-1.1.2.tgz#6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f"
+  dependencies:
+    path-exists "^2.0.0"
+    pinkie-promise "^2.0.0"
+
+find-up@^2.0.0, find-up@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
+  dependencies:
+    locate-path "^2.0.0"
+
+flat-cache@^1.2.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-1.3.0.tgz#d3030b32b38154f4e3b7e9c709f490f7ef97c481"
+  dependencies:
+    circular-json "^0.3.1"
+    del "^2.0.2"
+    graceful-fs "^4.1.2"
+    write "^0.2.1"
 
 flexbuffer@0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/flexbuffer/-/flexbuffer-0.0.6.tgz#039fdf23f8823e440c38f3277e6fef1174215b30"
 
-formatio@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/formatio/-/formatio-1.1.1.tgz#5ed3ccd636551097383465d996199100e86161e9"
-  dependencies:
-    samsam "~1.1"
+for-in@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
 
-fs-readdir-recursive@^0.1.0:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz#315b4fb8c1ca5b8c47defef319d073dad3568059"
+foreach@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/foreach/-/foreach-2.0.5.tgz#0bee005018aeb260d0a3af3ae658dd0136ec1b99"
+
+foreground-child@^1.5.3, foreground-child@^1.5.6:
+  version "1.5.6"
+  resolved "https://registry.yarnpkg.com/foreground-child/-/foreground-child-1.5.6.tgz#4fd71ad2dfde96789b980a5c0a295937cb2f5ce9"
+  dependencies:
+    cross-spawn "^4"
+    signal-exit "^3.0.0"
+
+fragment-cache@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/fragment-cache/-/fragment-cache-0.2.1.tgz#4290fad27f13e89be7f33799c6bc5a0abfff0d19"
+  dependencies:
+    map-cache "^0.2.2"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
 
+function-bind@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
+
+functional-red-black-tree@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
+
+get-caller-file@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"
+
 get-func-name@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
 
-get-stdin@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
+get-stream@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
 
-glob@5.x, glob@^5.0.1, glob@^5.0.15:
-  version "5.0.15"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-5.0.15.tgz#1bc936b9e02f4a603fcc222ecf7633d30b8b93b1"
-  dependencies:
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "2 || 3"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
+get-value@^2.0.3, get-value@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
 
-glob@7.1.1:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.0.2"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
-glob@^7.0.5, glob@^7.1.1:
+glob@7.1.2, glob@^7.0.3, glob@^7.0.5, glob@^7.0.6, glob@^7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
@@ -703,23 +939,30 @@ glob@^7.0.5, glob@^7.1.1:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-globals@^6.4.0:
-  version "6.4.1"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-6.4.1.tgz#8498032b3b6d1cc81eebc5f79690d8fe29fabf4f"
+globals@^11.1.0, globals@^11.7.0:
+  version "11.7.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-11.7.0.tgz#a583faa43055b1aca771914bf68258e2fc125673"
 
-graceful-fs@^4.1.2, graceful-fs@^4.1.4, graceful-fs@^4.1.9:
+globby@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-5.0.0.tgz#ebd84667ca0dbb330b99bcfc68eac2bc54370e0d"
+  dependencies:
+    array-union "^1.0.1"
+    arrify "^1.0.0"
+    glob "^7.0.3"
+    object-assign "^4.0.1"
+    pify "^2.0.0"
+    pinkie-promise "^2.0.0"
+
+graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.9:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
-"graceful-readlink@>= 1.0.0":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
+growl@1.10.5:
+  version "1.10.5"
+  resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
 
-growl@1.9.2:
-  version "1.9.2"
-  resolved "https://registry.yarnpkg.com/growl/-/growl-1.9.2.tgz#0ea7743715db8d8de2c5ede1775e1b45ac85c02f"
-
-handlebars@^4.0.1:
+handlebars@^4.0.11:
   version "4.0.11"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.0.11.tgz#630a35dfe0294bc281edae6ffc5d329fc7982dcc"
   dependencies:
@@ -735,44 +978,72 @@ has-ansi@^2.0.0:
   dependencies:
     ansi-regex "^2.0.0"
 
-has-color@~0.1.0:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/has-color/-/has-color-0.1.7.tgz#67144a5260c34fc3cca677d041daf52fe7b78b2f"
-
 has-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
+
+has-flag@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
+
+has-symbols@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.0.tgz#ba1a8f1af2a0fc39650f5c850367704122063b44"
+
+has-value@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/has-value/-/has-value-0.3.1.tgz#7b1f58bada62ca827ec0a2078025654845995e1f"
+  dependencies:
+    get-value "^2.0.3"
+    has-values "^0.1.4"
+    isobject "^2.0.0"
+
+has-value@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-value/-/has-value-1.0.0.tgz#18b281da585b1c5c51def24c930ed29a0be6b177"
+  dependencies:
+    get-value "^2.0.6"
+    has-values "^1.0.0"
+    isobject "^3.0.0"
+
+has-values@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/has-values/-/has-values-0.1.4.tgz#6d61de95d91dfca9b9a02089ad384bff8f62b771"
+
+has-values@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-values/-/has-values-1.0.0.tgz#95b0b63fec2146619a6fe57fe75628d5a39efe4f"
+  dependencies:
+    is-number "^3.0.0"
+    kind-of "^4.0.0"
+
+has@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
+  dependencies:
+    function-bind "^1.1.1"
 
 he@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
 
-home-or-tmp@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-1.0.0.tgz#4b9f1e40800c3e50c6c27f781676afcce71f3985"
-  dependencies:
-    os-tmpdir "^1.0.1"
-    user-home "^1.1.1"
+hosted-git-info@^2.1.4:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.7.1.tgz#97f236977bd6e125408930ff6de3eec6281ec047"
 
-htmlparser2@3.8.3, htmlparser2@3.8.x:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.8.3.tgz#996c28b191516a8be86501a7d79757e5c70c1068"
-  dependencies:
-    domelementtype "1"
-    domhandler "2.3"
-    domutils "1.5"
-    entities "1.0"
-    readable-stream "1.1"
-
-i@0.3.x:
-  version "0.3.6"
-  resolved "https://registry.yarnpkg.com/i/-/i-0.3.6.tgz#d96c92732076f072711b6b10fd7d4f65ad8ee23d"
-
-iconv-lite@^0.4.5:
+iconv-lite@^0.4.17:
   version "0.4.23"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.23.tgz#297871f63be507adcfbfca715d0cd0eed84e9a63"
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
+
+ignore@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.2.tgz#0a8dd228947ec78c2d7f736b1642a9f7317c1905"
+
+imurmurhash@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
 
 inflight@^1.0.4:
   version "1.0.6"
@@ -781,13 +1052,33 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherit@^2.2.2:
-  version "2.2.6"
-  resolved "https://registry.yarnpkg.com/inherit/-/inherit-2.2.6.tgz#f1614b06c8544e8128e4229c86347db73ad9788d"
-
-inherits@2, inherits@2.0.3, inherits@~2.0.1, inherits@~2.0.3:
+inherits@2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
+
+inquirer@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-5.2.0.tgz#db350c2b73daca77ff1243962e9f22f099685726"
+  dependencies:
+    ansi-escapes "^3.0.0"
+    chalk "^2.0.0"
+    cli-cursor "^2.1.0"
+    cli-width "^2.0.0"
+    external-editor "^2.1.0"
+    figures "^2.0.0"
+    lodash "^4.3.0"
+    mute-stream "0.0.7"
+    run-async "^2.2.0"
+    rxjs "^5.5.2"
+    string-width "^2.1.0"
+    strip-ansi "^4.0.0"
+    through "^2.3.6"
+
+invariant@^2.2.0:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
+  dependencies:
+    loose-envify "^1.0.0"
 
 invert-kv@^1.0.0:
   version "1.0.0"
@@ -806,31 +1097,151 @@ ioredis@^2.5.0:
     redis-commands "^1.2.0"
     redis-parser "^1.3.0"
 
+is-accessor-descriptor@^0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz#a9e12cb3ae8d876727eeef3843f8a0897b5c98d6"
+  dependencies:
+    kind-of "^3.0.2"
+
+is-accessor-descriptor@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz#169c2f6d3df1f992618072365c9b0ea1f6878656"
+  dependencies:
+    kind-of "^6.0.0"
+
+is-arrayish@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
+
 is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
 
-is-finite@^1.0.0:
+is-builtin-module@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-builtin-module/-/is-builtin-module-1.0.0.tgz#540572d34f7ac3119f8f76c30cbc1b1e037affbe"
+  dependencies:
+    builtin-modules "^1.0.0"
+
+is-callable@^1.1.1, is-callable@^1.1.3:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.4.tgz#1e1adf219e1eeb684d691f9d6a05ff0d30a24d75"
+
+is-data-descriptor@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz#0b5ee648388e2c860282e793f1856fec3f301b56"
+  dependencies:
+    kind-of "^3.0.2"
+
+is-data-descriptor@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz#d84876321d0e7add03990406abbbbd36ba9268c7"
+  dependencies:
+    kind-of "^6.0.0"
+
+is-date-object@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
+
+is-descriptor@^0.1.0:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/is-descriptor/-/is-descriptor-0.1.6.tgz#366d8240dde487ca51823b1ab9f07a10a78251ca"
+  dependencies:
+    is-accessor-descriptor "^0.1.6"
+    is-data-descriptor "^0.1.4"
+    kind-of "^5.0.0"
+
+is-descriptor@^1.0.0, is-descriptor@^1.0.2:
   version "1.0.2"
-  resolved "https://registry.yarnpkg.com/is-finite/-/is-finite-1.0.2.tgz#cc6677695602be550ef11e8b4aa6305342b6d0aa"
+  resolved "https://registry.yarnpkg.com/is-descriptor/-/is-descriptor-1.0.2.tgz#3b159746a66604b04f8c81524ba365c5f14d86ec"
+  dependencies:
+    is-accessor-descriptor "^1.0.0"
+    is-data-descriptor "^1.0.0"
+    kind-of "^6.0.2"
+
+is-extendable@^0.1.0, is-extendable@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-0.1.1.tgz#62b110e289a471418e3ec36a617d472e301dfc89"
+
+is-extendable@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-1.0.1.tgz#a7470f9e426733d81bd81e1155264e3a3507cab4"
+  dependencies:
+    is-plain-object "^2.0.4"
+
+is-fullwidth-code-point@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz#ef9e31386f031a7f0d643af82fde50c457ef00cb"
   dependencies:
     number-is-nan "^1.0.0"
 
-is-integer@^1.0.4:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/is-integer/-/is-integer-1.0.7.tgz#6bde81aacddf78b659b6629d629cadc51a886d5c"
+is-fullwidth-code-point@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
+
+is-number@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-number/-/is-number-3.0.0.tgz#24fd6201a4782cf50561c810276afc7d12d71195"
   dependencies:
-    is-finite "^1.0.0"
+    kind-of "^3.0.2"
+
+is-path-cwd@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-1.0.0.tgz#d225ec23132e89edd38fda767472e62e65f1106d"
+
+is-path-in-cwd@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz#5ac48b345ef675339bd6c7a48a912110b241cf52"
+  dependencies:
+    is-path-inside "^1.0.0"
+
+is-path-inside@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-1.0.1.tgz#8ef5b7de50437a3fdca6b4e865ef7aa55cb48036"
+  dependencies:
+    path-is-inside "^1.0.1"
+
+is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
+  dependencies:
+    isobject "^3.0.1"
+
+is-promise@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
+
+is-regex@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
+  dependencies:
+    has "^1.0.1"
+
+is-resolvable@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.1.0.tgz#fb18f87ce1feb925169c9a407c19318a3206ed88"
+
+is-stream@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
+
+is-symbol@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.1.tgz#3cc59f00025194b6ab2e38dbae6689256b660572"
 
 is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
 
+is-windows@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
+
 isarray@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
 
-isarray@~1.0.0:
+isarray@1.0.0, isarray@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
 
@@ -838,97 +1249,87 @@ isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
 
-isstream@0.1.x:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
-
-istanbul@^0.3.13:
-  version "0.3.22"
-  resolved "https://registry.yarnpkg.com/istanbul/-/istanbul-0.3.22.tgz#3e164d85021fe19c985d1f0e7ef0c3e22d012eb6"
+isobject@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/isobject/-/isobject-2.1.0.tgz#f065561096a3f1da2ef46272f815c840d87e0c89"
   dependencies:
-    abbrev "1.0.x"
-    async "1.x"
-    escodegen "1.7.x"
-    esprima "2.5.x"
-    fileset "0.2.x"
-    handlebars "^4.0.1"
-    js-yaml "3.x"
-    mkdirp "0.5.x"
-    nopt "3.x"
-    once "1.x"
-    resolve "1.1.x"
-    supports-color "^3.1.0"
-    which "^1.1.1"
-    wordwrap "^1.0.0"
+    isarray "1.0.0"
 
-js-tokens@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-1.0.1.tgz#cc435a5c8b94ad15acb7983140fc80182c89aeae"
+isobject@^3.0.0, isobject@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
 
-js-yaml@3.x:
+istanbul-lib-coverage@^1.1.2, istanbul-lib-coverage@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.0.tgz#f7d8f2e42b97e37fe796114cb0f9d68b5e3a4341"
+
+istanbul-lib-coverage@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz#2aee0e073ad8c5f6a0b00e0dfbf52b4667472eda"
+
+istanbul-lib-hook@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-hook/-/istanbul-lib-hook-1.1.0.tgz#8538d970372cb3716d53e55523dd54b557a8d89b"
+  dependencies:
+    append-transform "^0.4.0"
+
+istanbul-lib-instrument@^2.1.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-2.3.1.tgz#406406730a395acb2e50f0d98137ace16bd4a970"
+  dependencies:
+    "@babel/generator" "7.0.0-beta.51"
+    "@babel/parser" "7.0.0-beta.51"
+    "@babel/template" "7.0.0-beta.51"
+    "@babel/traverse" "7.0.0-beta.51"
+    "@babel/types" "7.0.0-beta.51"
+    istanbul-lib-coverage "^2.0.1"
+    semver "^5.5.0"
+
+istanbul-lib-report@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-1.1.3.tgz#2df12188c0fa77990c0d2176d2d0ba3394188259"
+  dependencies:
+    istanbul-lib-coverage "^1.1.2"
+    mkdirp "^0.5.1"
+    path-parse "^1.0.5"
+    supports-color "^3.1.2"
+
+istanbul-lib-source-maps@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.5.tgz#ffe6be4e7ab86d3603e4290d54990b14506fc9b1"
+  dependencies:
+    debug "^3.1.0"
+    istanbul-lib-coverage "^1.2.0"
+    mkdirp "^0.5.1"
+    rimraf "^2.6.1"
+    source-map "^0.5.3"
+
+istanbul-reports@^1.4.1:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-1.5.0.tgz#c6c2867fa65f59eb7dcedb7f845dfc76aaee70f9"
+  dependencies:
+    handlebars "^4.0.11"
+
+js-tokens@^3.0.0, js-tokens@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
+
+"js-tokens@^3.0.0 || ^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
+
+js-yaml@^3.11.0:
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-js-yaml@~3.4.0:
-  version "3.4.6"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.4.6.tgz#6be1b23f6249f53d293370fd4d1aaa63ce1b4eb0"
-  dependencies:
-    argparse "^1.0.2"
-    esprima "^2.6.0"
-    inherit "^2.2.2"
-
 js2xmlparser@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/js2xmlparser/-/js2xmlparser-3.0.0.tgz#3fb60eaa089c5440f9319f51760ccd07e2499733"
   dependencies:
     xmlcreate "^1.0.1"
-
-jscs-jsdoc@^1.3.1:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/jscs-jsdoc/-/jscs-jsdoc-1.3.2.tgz#1f2c82b6ab4b97524da958f46b4e562e0305f9a7"
-  dependencies:
-    comment-parser "^0.3.1"
-    jsdoctypeparser "~1.2.0"
-
-jscs-preset-wikimedia@~1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/jscs-preset-wikimedia/-/jscs-preset-wikimedia-1.0.1.tgz#a6a5fa5967fd67a5d609038e1c794eaf41d4233d"
-
-jscs@^2.11.0:
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/jscs/-/jscs-2.11.0.tgz#6e11ef0caaa07731f9dcc2b2b27d8ecee1ddbcb6"
-  dependencies:
-    babel-jscs "^2.0.0"
-    chalk "~1.1.0"
-    cli-table "~0.3.1"
-    commander "~2.9.0"
-    escope "^3.2.0"
-    esprima "~2.7.0"
-    estraverse "^4.1.0"
-    exit "~0.1.2"
-    glob "^5.0.1"
-    htmlparser2 "3.8.3"
-    js-yaml "~3.4.0"
-    jscs-jsdoc "^1.3.1"
-    jscs-preset-wikimedia "~1.0.0"
-    jsonlint "~1.6.2"
-    lodash "~3.10.0"
-    minimatch "~3.0.0"
-    natural-compare "~1.2.2"
-    pathval "~0.1.1"
-    prompt "~0.2.14"
-    reserved-words "^0.1.1"
-    resolve "^1.1.6"
-    strip-bom "^2.0.0"
-    strip-json-comments "~1.0.2"
-    to-double-quotes "^2.0.0"
-    to-single-quotes "^2.0.0"
-    vow "~0.4.8"
-    vow-fs "~0.3.4"
-    xmlbuilder "^3.1.0"
 
 jsdoc@^3.4.3:
   version "3.5.5"
@@ -947,49 +1348,41 @@ jsdoc@^3.4.3:
     taffydb "2.6.2"
     underscore "~1.8.3"
 
-jsdoctypeparser@~1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/jsdoctypeparser/-/jsdoctypeparser-1.2.0.tgz#e7dedc153a11849ffc5141144ae86a7ef0c25392"
-  dependencies:
-    lodash "^3.7.0"
+jsesc@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.1.tgz#e421a2a8e20d6b0819df28908f782526b96dd1fe"
 
-jsesc@~0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
+json-schema-traverse@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
 
-jshint@^2.7.0:
-  version "2.9.5"
-  resolved "https://registry.yarnpkg.com/jshint/-/jshint-2.9.5.tgz#1e7252915ce681b40827ee14248c46d34e9aa62c"
-  dependencies:
-    cli "~1.0.0"
-    console-browserify "1.1.x"
-    exit "0.1.x"
-    htmlparser2 "3.8.x"
-    lodash "3.7.x"
-    minimatch "~3.0.2"
-    shelljs "0.3.x"
-    strip-json-comments "1.0.x"
+json-stable-stringify-without-jsonify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
 
-json3@3.3.2:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.2.tgz#3c0434743df93e2f5c42aee7b19bcb483575f4e1"
+just-extend@^1.1.27:
+  version "1.1.27"
+  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-1.1.27.tgz#ec6e79410ff914e472652abfa0e603c03d60e905"
 
-json5@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-0.4.0.tgz#054352e4c4c80c86c0923877d449de176a732c8d"
-
-jsonlint@~1.6.2:
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/jsonlint/-/jsonlint-1.6.3.tgz#cb5e31efc0b78291d0d862fbef05900adf212988"
-  dependencies:
-    JSV "^4.0.x"
-    nomnom "^1.5.x"
-
-kind-of@^3.0.2:
+kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
   dependencies:
     is-buffer "^1.1.5"
+
+kind-of@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-4.0.0.tgz#20813df3d712928b207378691a45066fae72dd57"
+  dependencies:
+    is-buffer "^1.1.5"
+
+kind-of@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-5.1.0.tgz#729c91e2d857b7a419a1f9aa65685c4c33f5845d"
+
+kind-of@^6.0.0, kind-of@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
 
 klaw@~2.0.0:
   version "2.0.0"
@@ -1007,160 +1400,174 @@ lcid@^1.0.0:
   dependencies:
     invert-kv "^1.0.0"
 
-leven@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/leven/-/leven-1.0.2.tgz#9144b6eebca5f1d0680169f1a6770dcea60b75c3"
-
-levn@~0.2.5:
-  version "0.2.5"
-  resolved "https://registry.yarnpkg.com/levn/-/levn-0.2.5.tgz#ba8d339d0ca4a610e3a3f145b9caf48807155054"
+levn@^0.3.0, levn@~0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
   dependencies:
-    prelude-ls "~1.1.0"
-    type-check "~0.3.1"
+    prelude-ls "~1.1.2"
+    type-check "~0.3.2"
 
-lodash._baseassign@^3.0.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz#8c38a099500f215ad09e59f1722fd0c52bfe0a4e"
+load-json-file@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"
   dependencies:
-    lodash._basecopy "^3.0.0"
-    lodash.keys "^3.0.0"
+    graceful-fs "^4.1.2"
+    parse-json "^2.2.0"
+    pify "^2.0.0"
+    pinkie-promise "^2.0.0"
+    strip-bom "^2.0.0"
 
-lodash._basecopy@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz#8da0e6a876cf344c0ad8a54882111dd3c5c7ca36"
-
-lodash._basecreate@^3.0.0:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz#1bc661614daa7fc311b7d03bf16806a0213cf821"
-
-lodash._bindcallback@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-
-lodash._createassigner@^3.0.0:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz#838a5bae2fdaca63ac22dee8e19fa4e6d6970b11"
+load-json-file@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-2.0.0.tgz#7947e42149af80d696cbf797bcaabcfe1fe29ca8"
   dependencies:
-    lodash._bindcallback "^3.0.0"
-    lodash._isiterateecall "^3.0.0"
-    lodash.restparam "^3.0.0"
+    graceful-fs "^4.1.2"
+    parse-json "^2.2.0"
+    pify "^2.0.0"
+    strip-bom "^3.0.0"
 
-lodash._getnative@^3.0.0:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
-
-lodash._isiterateecall@^3.0.0:
-  version "3.0.9"
-  resolved "https://registry.yarnpkg.com/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz#5203ad7ba425fae842460e696db9cf3e6aac057c"
-
-lodash.assign@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/lodash.assign/-/lodash.assign-3.2.0.tgz#3ce9f0234b4b2223e296b8fa0ac1fee8ebca64fa"
+locate-path@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
   dependencies:
-    lodash._baseassign "^3.0.0"
-    lodash._createassigner "^3.0.0"
-    lodash.keys "^3.0.0"
+    p-locate "^2.0.0"
+    path-exists "^3.0.0"
 
-lodash.create@3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/lodash.create/-/lodash.create-3.1.1.tgz#d7f2849f0dbda7e04682bb8cd72ab022461debe7"
-  dependencies:
-    lodash._baseassign "^3.0.0"
-    lodash._basecreate "^3.0.0"
-    lodash._isiterateecall "^3.0.0"
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
 
-lodash.isarguments@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"
-
-lodash.isarray@^3.0.0:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
-
-lodash.keys@^3.0.0:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash.keys/-/lodash.keys-3.1.2.tgz#4dbc0472b156be50a0b286855d1bd0b0c656098a"
-  dependencies:
-    lodash._getnative "^3.0.0"
-    lodash.isarguments "^3.0.0"
-    lodash.isarray "^3.0.0"
-
-lodash.restparam@^3.0.0:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
-
-lodash@3.7.x:
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.7.0.tgz#3678bd8ab995057c07ade836ed2ef087da811d45"
-
-lodash@^3.10.0, lodash@^3.5.0, lodash@^3.7.0, lodash@^3.9.3, lodash@~3.10.0:
+lodash@^3.10.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
-lodash@^4.8.2:
+lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0, lodash@^4.8.2:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
-lolex@1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.3.2.tgz#7c3da62ffcb30f0f5a80a2566ca24e45d8a01f31"
+lolex@^2.3.2, lolex@^2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-2.7.1.tgz#e40a8c4d1f14b536aa03e42a537c7adbaf0c20be"
 
 longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
+loose-envify@^1.0.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
+  dependencies:
+    js-tokens "^3.0.0 || ^4.0.0"
+
+lru-cache@^4.0.1:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.3.tgz#a1175cf3496dfc8436c156c334b4955992bce69c"
+  dependencies:
+    pseudomap "^1.0.2"
+    yallist "^2.1.2"
+
+map-cache@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/map-cache/-/map-cache-0.2.2.tgz#c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf"
+
+map-visit@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/map-visit/-/map-visit-1.0.0.tgz#ecdca8f13144e660f1b5bd41f12f3479d98dfb8f"
+  dependencies:
+    object-visit "^1.0.0"
+
 marked@~0.3.6:
   version "0.3.19"
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.19.tgz#5d47f709c4c9fc3c216b6d46127280f40b39d790"
 
-"minimatch@2 || 3", minimatch@^3.0.2, minimatch@^3.0.4, minimatch@~3.0.0, minimatch@~3.0.2:
+md5-hex@^1.2.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/md5-hex/-/md5-hex-1.3.0.tgz#d2c4afe983c4370662179b8cad145219135046c4"
+  dependencies:
+    md5-o-matic "^0.1.1"
+
+md5-o-matic@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/md5-o-matic/-/md5-o-matic-0.1.1.tgz#822bccd65e117c514fab176b25945d54100a03c3"
+
+mem@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/mem/-/mem-1.1.0.tgz#5edd52b485ca1d900fe64895505399a0dfa45f76"
+  dependencies:
+    mimic-fn "^1.0.0"
+
+merge-source-map@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/merge-source-map/-/merge-source-map-1.1.0.tgz#2fdde7e6020939f70906a68f2d7ae685e4c8c646"
+  dependencies:
+    source-map "^0.6.1"
+
+micromatch@^3.1.10, micromatch@^3.1.8:
+  version "3.1.10"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
+  dependencies:
+    arr-diff "^4.0.0"
+    array-unique "^0.3.2"
+    braces "^2.3.1"
+    define-property "^2.0.2"
+    extend-shallow "^3.0.2"
+    extglob "^2.0.4"
+    fragment-cache "^0.2.1"
+    kind-of "^6.0.2"
+    nanomatch "^1.2.9"
+    object.pick "^1.3.0"
+    regex-not "^1.0.0"
+    snapdragon "^0.8.1"
+    to-regex "^3.0.2"
+
+mimic-fn@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
+
+minimatch@3.0.4, minimatch@^3.0.3, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
     brace-expansion "^1.1.7"
 
-minimatch@2.x, minimatch@^2.0.3:
-  version "2.0.10"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-2.0.10.tgz#8d087c39c6b38c001b97fca7ce6d0e1e80afbac7"
-  dependencies:
-    brace-expansion "^1.0.0"
-
 minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
-
-minimist@^1.1.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
 minimist@~0.0.1:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
 
-mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@0.x.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.1:
+mixin-deep@^1.2.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.1.tgz#a49e7268dce1a0d9698e45326c5626df3543d0fe"
+  dependencies:
+    for-in "^1.0.2"
+    is-extendable "^1.0.1"
+
+mkdirp@0.5.1, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
     minimist "0.0.8"
 
-mocha@^3.5.0:
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-3.5.3.tgz#1e0480fe36d2da5858d1eb6acc38418b26eaa20d"
+mocha@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-5.2.0.tgz#6d8ae508f59167f940f2b5b3c4a612ae50c90ae6"
   dependencies:
-    browser-stdout "1.3.0"
-    commander "2.9.0"
-    debug "2.6.8"
-    diff "3.2.0"
+    browser-stdout "1.3.1"
+    commander "2.15.1"
+    debug "3.1.0"
+    diff "3.5.0"
     escape-string-regexp "1.0.5"
-    glob "7.1.1"
-    growl "1.9.2"
+    glob "7.1.2"
+    growl "1.10.5"
     he "1.1.1"
-    json3 "3.3.2"
-    lodash.create "3.1.1"
+    minimatch "3.0.4"
     mkdirp "0.5.1"
-    supports-color "3.1.2"
+    supports-color "5.4.0"
 
-moment@^2.11.1:
+moment@^2.22.2:
   version "2.22.2"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
 
@@ -1168,48 +1575,134 @@ ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
 
-mute-stream@~0.0.4:
+mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
 
-natural-compare@~1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.2.2.tgz#1f96d60e3141cac1b6d05653ce0daeac763af6aa"
-
-ncp@0.4.x:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/ncp/-/ncp-0.4.2.tgz#abcc6cbd3ec2ed2a729ff6e7c1fa8f01784a8574"
-
-next-tick@1:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
-
-nomnom@^1.5.x:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/nomnom/-/nomnom-1.8.1.tgz#2151f722472ba79e50a76fc125bb8c8f2e4dc2a7"
+nanomatch@^1.2.9:
+  version "1.2.13"
+  resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
   dependencies:
-    chalk "~0.4.0"
-    underscore "~1.6.0"
+    arr-diff "^4.0.0"
+    array-unique "^0.3.2"
+    define-property "^2.0.2"
+    extend-shallow "^3.0.2"
+    fragment-cache "^0.2.1"
+    is-windows "^1.0.2"
+    kind-of "^6.0.2"
+    object.pick "^1.3.0"
+    regex-not "^1.0.0"
+    snapdragon "^0.8.1"
+    to-regex "^3.0.1"
 
-nopt@3.x:
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"
+natural-compare@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
+
+nice-try@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.4.tgz#d93962f6c52f2c1558c0fbda6d512819f1efe1c4"
+
+nise@^1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-1.4.2.tgz#a9a3800e3994994af9e452333d549d60f72b8e8c"
   dependencies:
-    abbrev "1"
+    "@sinonjs/formatio" "^2.0.0"
+    just-extend "^1.1.27"
+    lolex "^2.3.2"
+    path-to-regexp "^1.7.0"
+    text-encoding "^0.6.4"
+
+normalize-package-data@^2.3.2:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.4.0.tgz#12f95a307d58352075a04907b84ac8be98ac012f"
+  dependencies:
+    hosted-git-info "^2.1.4"
+    is-builtin-module "^1.0.0"
+    semver "2 || 3 || 4 || 5"
+    validate-npm-package-license "^3.0.1"
+
+npm-run-path@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
+  dependencies:
+    path-key "^2.0.0"
 
 number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
 
-object-assign@^4.1.0:
+nyc@^12.0.2:
+  version "12.0.2"
+  resolved "https://registry.yarnpkg.com/nyc/-/nyc-12.0.2.tgz#8a4a4ed690966c11ec587ff87eea0c12c974ba99"
+  dependencies:
+    archy "^1.0.0"
+    arrify "^1.0.1"
+    caching-transform "^1.0.0"
+    convert-source-map "^1.5.1"
+    debug-log "^1.0.1"
+    default-require-extensions "^1.0.0"
+    find-cache-dir "^0.1.1"
+    find-up "^2.1.0"
+    foreground-child "^1.5.3"
+    glob "^7.0.6"
+    istanbul-lib-coverage "^1.2.0"
+    istanbul-lib-hook "^1.1.0"
+    istanbul-lib-instrument "^2.1.0"
+    istanbul-lib-report "^1.1.3"
+    istanbul-lib-source-maps "^1.2.5"
+    istanbul-reports "^1.4.1"
+    md5-hex "^1.2.0"
+    merge-source-map "^1.1.0"
+    micromatch "^3.1.10"
+    mkdirp "^0.5.0"
+    resolve-from "^2.0.0"
+    rimraf "^2.6.2"
+    signal-exit "^3.0.1"
+    spawn-wrap "^1.4.2"
+    test-exclude "^4.2.0"
+    yargs "11.1.0"
+    yargs-parser "^8.0.0"
+
+object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
-once@1.x, once@^1.3.0:
+object-copy@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/object-copy/-/object-copy-0.1.0.tgz#7e7d858b781bd7c991a41ba975ed3812754e998c"
+  dependencies:
+    copy-descriptor "^0.1.0"
+    define-property "^0.2.5"
+    kind-of "^3.0.3"
+
+object-keys@^1.0.8:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.12.tgz#09c53855377575310cca62f55bb334abff7b3ed2"
+
+object-visit@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/object-visit/-/object-visit-1.0.1.tgz#f79c4493af0c5377b59fe39d395e41042dd045bb"
+  dependencies:
+    isobject "^3.0.0"
+
+object.pick@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/object.pick/-/object.pick-1.3.0.tgz#87a10ac4c1694bd2e1cbf53591a66141fb5dd747"
+  dependencies:
+    isobject "^3.0.1"
+
+once@^1.3.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   dependencies:
     wrappy "1"
+
+onetime@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-2.0.1.tgz#067428230fd67443b2794b22bba528b6867962d4"
+  dependencies:
+    mimic-fn "^1.0.0"
 
 optimist@^0.6.1:
   version "0.6.1"
@@ -1218,142 +1711,190 @@ optimist@^0.6.1:
     minimist "~0.0.1"
     wordwrap "~0.0.2"
 
-optionator@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.5.0.tgz#b75a8995a2d417df25b6e4e3862f50aa88651368"
+optionator@^0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.2.tgz#364c5e409d3f4d6301d6c0b4c05bba50180aeb64"
   dependencies:
-    deep-is "~0.1.2"
-    fast-levenshtein "~1.0.0"
-    levn "~0.2.5"
-    prelude-ls "~1.1.1"
-    type-check "~0.3.1"
-    wordwrap "~0.0.2"
+    deep-is "~0.1.3"
+    fast-levenshtein "~2.0.4"
+    levn "~0.3.0"
+    prelude-ls "~1.1.2"
+    type-check "~0.3.2"
+    wordwrap "~1.0.0"
 
-os-locale@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-1.4.0.tgz#20f9f17ae29ed345e8bde583b13d2009803c14d9"
+os-homedir@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
+
+os-locale@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-2.1.0.tgz#42bc2900a6b5b8bd17376c8e882b65afccf24bf2"
   dependencies:
+    execa "^0.7.0"
     lcid "^1.0.0"
+    mem "^1.1.0"
 
-os-tmpdir@^1.0.1:
+os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
 
-output-file-sync@^1.1.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/output-file-sync/-/output-file-sync-1.1.2.tgz#d0a33eefe61a205facb90092e826598d5245ce76"
-  dependencies:
-    graceful-fs "^4.1.4"
-    mkdirp "^0.5.1"
-    object-assign "^4.1.0"
-
-path-exists@^1.0.0:
+p-finally@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-1.0.0.tgz#d5a8998eb71ef37a74c34eb0d9eba6e878eea081"
+  resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
+
+p-limit@^1.1.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.3.0.tgz#b86bd5f0c25690911c7590fcbfc2010d54b3ccb8"
+  dependencies:
+    p-try "^1.0.0"
+
+p-locate@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
+  dependencies:
+    p-limit "^1.1.0"
+
+p-try@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
+
+parse-json@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-2.2.0.tgz#f480f40434ef80741f8469099f8dea18f55a4dc9"
+  dependencies:
+    error-ex "^1.2.0"
+
+pascalcase@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
+
+path-exists@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-2.1.0.tgz#0feb6c64f0fc518d9a754dd5efb62c7022761f4b"
+  dependencies:
+    pinkie-promise "^2.0.0"
+
+path-exists@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
 
 path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
 
+path-is-inside@^1.0.1, path-is-inside@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
+
+path-key@^2.0.0, path-key@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
+
 path-parse@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
+
+path-to-regexp@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
+  dependencies:
+    isarray "0.0.1"
+
+path-type@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-1.1.0.tgz#59c44f7ee491da704da415da5a4070ba4f8fe441"
+  dependencies:
+    graceful-fs "^4.1.2"
+    pify "^2.0.0"
+    pinkie-promise "^2.0.0"
+
+path-type@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-2.0.0.tgz#f012ccb8415b7096fc2daa1054c3d72389594c73"
+  dependencies:
+    pify "^2.0.0"
 
 pathval@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
 
-pathval@~0.1.1:
+pify@^2.0.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
+
+pinkie-promise@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz#2135d6dfa7a358c069ac9b178776288228450ffa"
+  dependencies:
+    pinkie "^2.0.0"
+
+pinkie@^2.0.0:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
+
+pkg-dir@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-1.0.0.tgz#7a4b508a8d5bb2d629d447056ff4e9c9314cf3d4"
+  dependencies:
+    find-up "^1.0.0"
+
+pluralize@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
+
+posix-character-classes@^0.1.0:
   version "0.1.1"
-  resolved "https://registry.yarnpkg.com/pathval/-/pathval-0.1.1.tgz#08f911cdca9cce5942880da7817bc0b723b66d82"
+  resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
 
-pkginfo@0.3.x:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/pkginfo/-/pkginfo-0.3.1.tgz#5b29f6a81f70717142e09e765bbeab97b4f81e21"
-
-pkginfo@0.x.x:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/pkginfo/-/pkginfo-0.4.1.tgz#b5418ef0439de5425fc4995042dced14fb2a84ff"
-
-prelude-ls@~1.1.0, prelude-ls@~1.1.1, prelude-ls@~1.1.2:
+prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
 
-private@^0.1.6, private@~0.1.5:
-  version "0.1.8"
-  resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
-
-process-nextick-args@~2.0.0:
+progress@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
 
-prompt@~0.2.14:
-  version "0.2.14"
-  resolved "https://registry.yarnpkg.com/prompt/-/prompt-0.2.14.tgz#57754f64f543fd7b0845707c818ece618f05ffdc"
+pseudomap@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
+
+punycode@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
+
+ramda@^0.25.0:
+  version "0.25.0"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.25.0.tgz#8fdf68231cffa90bc2f9460390a0cb74a29b29a9"
+
+read-pkg-up@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-1.0.1.tgz#9d63c13276c065918d57f002a57f40a1b643fb02"
   dependencies:
-    pkginfo "0.x.x"
-    read "1.0.x"
-    revalidator "0.1.x"
-    utile "0.2.x"
-    winston "0.8.x"
+    find-up "^1.0.0"
+    read-pkg "^1.0.0"
 
-q@^1.1.2:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
-
-read@1.0.x:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/read/-/read-1.0.7.tgz#b3da19bd052431a97671d44a42634adf710b40c4"
+read-pkg-up@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-2.0.0.tgz#6b72a8048984e0c41e79510fd5e9fa99b3b549be"
   dependencies:
-    mute-stream "~0.0.4"
+    find-up "^2.0.0"
+    read-pkg "^2.0.0"
 
-readable-stream@1.1:
-  version "1.1.13"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.13.tgz#f6eef764f514c89e2b9e23146a75ba106756d23e"
+read-pkg@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-1.1.0.tgz#f5ffaa5ecd29cb31c0474bca7d756b6bb29e3f28"
   dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.1"
-    isarray "0.0.1"
-    string_decoder "~0.10.x"
+    load-json-file "^1.0.0"
+    normalize-package-data "^2.3.2"
+    path-type "^1.0.0"
 
-readable-stream@^2.0.4:
-  version "2.3.6"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
+read-pkg@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-2.0.0.tgz#8ef1c0623c6a6db0dc6713c4bfac46332b2368f8"
   dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.3"
-    isarray "~1.0.0"
-    process-nextick-args "~2.0.0"
-    safe-buffer "~5.1.1"
-    string_decoder "~1.1.1"
-    util-deprecate "~1.0.1"
-
-recast@0.10.33:
-  version "0.10.33"
-  resolved "https://registry.yarnpkg.com/recast/-/recast-0.10.33.tgz#942808f7aa016f1fa7142c461d7e5704aaa8d697"
-  dependencies:
-    ast-types "0.8.12"
-    esprima-fb "~15001.1001.0-dev-harmony-fb"
-    private "~0.1.5"
-    source-map "~0.5.0"
-
-recast@^0.10.10:
-  version "0.10.43"
-  resolved "https://registry.yarnpkg.com/recast/-/recast-0.10.43.tgz#b95d50f6d60761a5f6252e15d80678168491ce7f"
-  dependencies:
-    ast-types "0.8.15"
-    esprima-fb "~15001.1001.0-dev-harmony-fb"
-    private "~0.1.5"
-    source-map "~0.5.0"
-
-recast@^0.11.17:
-  version "0.11.23"
-  resolved "https://registry.yarnpkg.com/recast/-/recast-0.11.23.tgz#451fd3004ab1e4df9b4e4b66376b2a21912462d3"
-  dependencies:
-    ast-types "0.9.6"
-    esprima "~3.1.0"
-    private "~0.1.5"
-    source-map "~0.5.0"
+    load-json-file "^2.0.0"
+    normalize-package-data "^2.3.2"
+    path-type "^2.0.0"
 
 redis-commands@^1.2.0:
   version "1.3.5"
@@ -1375,50 +1916,45 @@ redis@^2.5.3:
     redis-commands "^1.2.0"
     redis-parser "^2.6.0"
 
-regenerate@^1.2.1:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.0.tgz#4a856ec4b56e4077c557589cae85e7a4c8869a11"
-
-regenerator@0.8.40:
-  version "0.8.40"
-  resolved "https://registry.yarnpkg.com/regenerator/-/regenerator-0.8.40.tgz#a0e457c58ebdbae575c9f8cd75127e93756435d8"
+regex-not@^1.0.0, regex-not@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/regex-not/-/regex-not-1.0.2.tgz#1f4ece27e00b0b65e0247a6810e6a85d83a5752c"
   dependencies:
-    commoner "~0.10.3"
-    defs "~1.1.0"
-    esprima-fb "~15001.1001.0-dev-harmony-fb"
-    private "~0.1.5"
-    recast "0.10.33"
-    through "~2.3.8"
+    extend-shallow "^3.0.2"
+    safe-regex "^1.1.0"
 
-regexpu@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/regexpu/-/regexpu-1.3.0.tgz#e534dc991a9e5846050c98de6d7dd4a55c9ea16d"
+regexp.prototype.flags@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.2.0.tgz#6b30724e306a27833eeb171b66ac8890ba37e41c"
   dependencies:
-    esprima "^2.6.0"
-    recast "^0.10.10"
-    regenerate "^1.2.1"
-    regjsgen "^0.2.0"
-    regjsparser "^0.1.4"
+    define-properties "^1.1.2"
 
-regjsgen@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/regjsgen/-/regjsgen-0.2.0.tgz#6c016adeac554f75823fe37ac05b92d5a4edb1f7"
+regexpp@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-1.1.0.tgz#0e3516dd0b7904f413d2d4193dce4618c3a689ab"
 
-regjsparser@^0.1.4:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/regjsparser/-/regjsparser-0.1.5.tgz#7ee8f84dc6fa792d3fd0ae228d24bd949ead205c"
-  dependencies:
-    jsesc "~0.5.0"
+repeat-element@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.2.tgz#ef089a178d1483baae4d93eb98b4f9e4e11d990a"
 
-repeat-string@^1.5.2:
+repeat-string@^1.5.2, repeat-string@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
 
-repeating@^1.1.0, repeating@^1.1.2:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/repeating/-/repeating-1.1.3.tgz#3d4114218877537494f97f77f9785fab810fa4ac"
+require-directory@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
+
+require-main-filename@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
+
+require-uncached@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/require-uncached/-/require-uncached-1.0.3.tgz#4e0d56d6c9662fd31e43011c4b95aa49955421d3"
   dependencies:
-    is-finite "^1.0.0"
+    caller-path "^0.1.0"
+    resolve-from "^1.0.0"
 
 requizzle@~0.2.1:
   version "0.2.1"
@@ -1426,23 +1962,34 @@ requizzle@~0.2.1:
   dependencies:
     underscore "~1.6.0"
 
-reserved-words@^0.1.1:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/reserved-words/-/reserved-words-0.1.2.tgz#00a0940f98cd501aeaaac316411d9adc52b31ab1"
+resolve-from@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
 
-resolve@1.1.x:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
+resolve-from@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-2.0.0.tgz#9480ab20e94ffa1d9e80a804c7ea147611966b57"
 
-resolve@^1.1.6:
+resolve-url@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
+
+resolve@^1.5.0, resolve@^1.6.0:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.8.1.tgz#82f1ec19a423ac1fbd080b0bab06ba36e84a7a26"
   dependencies:
     path-parse "^1.0.5"
 
-revalidator@0.1.x:
-  version "0.1.8"
-  resolved "https://registry.yarnpkg.com/revalidator/-/revalidator-0.1.8.tgz#fece61bfa0c1b52a206bd6b18198184bdd523a3b"
+restore-cursor@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-2.0.0.tgz#9f7ee287f82fd326d4fd162923d62129eee0dfaf"
+  dependencies:
+    onetime "^2.0.0"
+    signal-exit "^3.0.2"
+
+ret@~0.1.10:
+  version "0.1.15"
+  resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
 
 right-align@^0.1.1:
   version "0.1.3"
@@ -1450,68 +1997,141 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@2.x.x:
+rimraf@^2.2.8, rimraf@^2.6.1, rimraf@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   dependencies:
     glob "^7.0.5"
 
-safe-buffer@~5.1.0, safe-buffer@~5.1.1:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
+run-async@^2.2.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0"
+  dependencies:
+    is-promise "^2.1.0"
+
+rxjs@^5.5.2:
+  version "5.5.11"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.11.tgz#f733027ca43e3bec6b994473be4ab98ad43ced87"
+  dependencies:
+    symbol-observable "1.0.1"
+
+safe-regex@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/safe-regex/-/safe-regex-1.1.0.tgz#40a3669f3b077d1e943d44629e157dd48023bf2e"
+  dependencies:
+    ret "~0.1.10"
 
 "safer-buffer@>= 2.1.2 < 3":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
 
-samsam@1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.1.2.tgz#bec11fdc83a9fda063401210e40176c3024d1567"
+samsam@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.3.0.tgz#8d1d9350e25622da30de3e44ba692b5221ab7c50"
 
-samsam@~1.1:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.1.3.tgz#9f5087419b4d091f232571e7fa52e90b0f552621"
+"semver@2 || 3 || 4 || 5", semver@^5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
+
+set-blocking@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
+
+set-value@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/set-value/-/set-value-0.4.3.tgz#7db08f9d3d22dc7f78e53af3c3bf4666ecdfccf1"
+  dependencies:
+    extend-shallow "^2.0.1"
+    is-extendable "^0.1.1"
+    is-plain-object "^2.0.1"
+    to-object-path "^0.3.0"
+
+set-value@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/set-value/-/set-value-2.0.0.tgz#71ae4a88f0feefbbf52d1ea604f3fb315ebb6274"
+  dependencies:
+    extend-shallow "^2.0.1"
+    is-extendable "^0.1.1"
+    is-plain-object "^2.0.3"
+    split-string "^3.0.1"
+
+shebang-command@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
+  dependencies:
+    shebang-regex "^1.0.0"
 
 shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
 
-shelljs@0.3.x:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.3.0.tgz#3596e6307a781544f591f37da618360f31db57b1"
+signal-exit@^3.0.0, signal-exit@^3.0.1, signal-exit@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
 
-simple-fmt@~0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/simple-fmt/-/simple-fmt-0.1.0.tgz#191bf566a59e6530482cb25ab53b4a8dc85c3a6b"
-
-simple-is@~0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/simple-is/-/simple-is-0.2.0.tgz#2abb75aade39deb5cc815ce10e6191164850baf0"
-
-sinon@^1.14.1:
-  version "1.17.7"
-  resolved "https://registry.yarnpkg.com/sinon/-/sinon-1.17.7.tgz#4542a4f49ba0c45c05eb2e9dd9d203e2b8efe0bf"
+sinon@^6.1.4:
+  version "6.1.4"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-6.1.4.tgz#b67f7a7b7fe2496042b54a5c2f425e2d699927a2"
   dependencies:
-    formatio "1.1.1"
-    lolex "1.3.2"
-    samsam "1.1.2"
-    util ">=0.10.3 <1"
+    "@sinonjs/formatio" "^2.0.0"
+    "@sinonjs/samsam" "^2.0.0"
+    diff "^3.5.0"
+    lodash.get "^4.4.2"
+    lolex "^2.7.1"
+    nise "^1.4.2"
+    supports-color "^5.4.0"
+    type-detect "^4.0.8"
 
-slash@^1.0.0:
+slice-ansi@1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
-
-source-map-support@^0.2.10:
-  version "0.2.10"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.2.10.tgz#ea5a3900a1c1cb25096a0ae8cc5c2b4b10ded3dc"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-1.0.0.tgz#044f1a49d8842ff307aad6b505ed178bd950134d"
   dependencies:
-    source-map "0.1.32"
+    is-fullwidth-code-point "^2.0.0"
 
-source-map@0.1.32:
-  version "0.1.32"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.1.32.tgz#c8b6c167797ba4740a8ea33252162ff08591b266"
+slide@^1.1.5:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/slide/-/slide-1.1.6.tgz#56eb027d65b4d2dce6cb2e2d32c4d4afc9e1d707"
+
+snapdragon-node@^2.0.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b"
   dependencies:
-    amdefine ">=0.0.4"
+    define-property "^1.0.0"
+    isobject "^3.0.0"
+    snapdragon-util "^3.0.1"
+
+snapdragon-util@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/snapdragon-util/-/snapdragon-util-3.0.1.tgz#f956479486f2acd79700693f6f7b805e45ab56e2"
+  dependencies:
+    kind-of "^3.2.0"
+
+snapdragon@^0.8.1:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/snapdragon/-/snapdragon-0.8.2.tgz#64922e7c565b0e14204ba1aa7d6964278d25182d"
+  dependencies:
+    base "^0.11.1"
+    debug "^2.2.0"
+    define-property "^0.2.5"
+    extend-shallow "^2.0.1"
+    map-cache "^0.2.2"
+    source-map "^0.5.6"
+    source-map-resolve "^0.5.0"
+    use "^3.1.0"
+
+source-map-resolve@^0.5.0:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.2.tgz#72e2cc34095543e43b2c62b2c4c10d4a9054f259"
+  dependencies:
+    atob "^2.1.1"
+    decode-uri-component "^0.2.0"
+    resolve-url "^0.2.1"
+    source-map-url "^0.4.0"
+    urix "^0.1.0"
+
+source-map-url@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
 
 source-map@^0.4.4:
   version "0.4.4"
@@ -1519,55 +2139,100 @@ source-map@^0.4.4:
   dependencies:
     amdefine ">=0.0.4"
 
-source-map@^0.5.0, source-map@~0.5.0, source-map@~0.5.1:
+source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.1:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
 
-source-map@~0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.2.0.tgz#dab73fbcfc2ba819b4de03bd6f6eaa48164b3f9d"
+source-map@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+
+spawn-wrap@^1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/spawn-wrap/-/spawn-wrap-1.4.2.tgz#cff58e73a8224617b6561abdc32586ea0c82248c"
   dependencies:
-    amdefine ">=0.0.4"
+    foreground-child "^1.5.6"
+    mkdirp "^0.5.0"
+    os-homedir "^1.0.1"
+    rimraf "^2.6.2"
+    signal-exit "^3.0.2"
+    which "^1.3.0"
+
+spdx-correct@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.0.0.tgz#05a5b4d7153a195bc92c3c425b69f3b2a9524c82"
+  dependencies:
+    spdx-expression-parse "^3.0.0"
+    spdx-license-ids "^3.0.0"
+
+spdx-exceptions@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz#2c7ae61056c714a5b9b9b2b2af7d311ef5c78fe9"
+
+spdx-expression-parse@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz#99e119b7a5da00e05491c9fa338b7904823b41d0"
+  dependencies:
+    spdx-exceptions "^2.1.0"
+    spdx-license-ids "^3.0.0"
+
+spdx-license-ids@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz#7a7cd28470cc6d3a1cfe6d66886f6bc430d3ac87"
+
+split-string@^3.0.1, split-string@^3.0.2:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
+  dependencies:
+    extend-shallow "^3.0.0"
 
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
 
-stable@~0.1.3:
-  version "0.1.8"
-  resolved "https://registry.yarnpkg.com/stable/-/stable-0.1.8.tgz#836eb3c8382fe2936feaf544631017ce7d47a3cf"
-
-stack-trace@0.0.x:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
-
-string_decoder@~0.10.x:
-  version "0.10.31"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
-
-string_decoder@~1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
+static-extend@^0.1.1:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
   dependencies:
-    safe-buffer "~5.1.0"
+    define-property "^0.2.5"
+    object-copy "^0.1.0"
 
-stringmap@~0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/stringmap/-/stringmap-0.2.2.tgz#556c137b258f942b8776f5b2ef582aa069d7d1b1"
+string-width@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
+  dependencies:
+    code-point-at "^1.0.0"
+    is-fullwidth-code-point "^1.0.0"
+    strip-ansi "^3.0.0"
 
-stringset@~0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/stringset/-/stringset-0.2.1.tgz#ef259c4e349344377fcd1c913dd2e848c9c042b5"
+string-width@^2.0.0, string-width@^2.1.0, string-width@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
+  dependencies:
+    is-fullwidth-code-point "^2.0.0"
+    strip-ansi "^4.0.0"
 
-strip-ansi@^3.0.0:
+string.prototype.matchall@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/string.prototype.matchall/-/string.prototype.matchall-2.0.0.tgz#2af8fe3d2d6dc53ca2a59bd376b089c3c152b3c8"
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.10.0"
+    function-bind "^1.1.1"
+    has-symbols "^1.0.0"
+    regexp.prototype.flags "^1.2.0"
+
+strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
   dependencies:
     ansi-regex "^2.0.0"
 
-strip-ansi@~0.1.0:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-0.1.1.tgz#39e8a98d044d150660abe4a6808acf70bb7bc991"
+strip-ansi@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
+  dependencies:
+    ansi-regex "^3.0.0"
 
 strip-bom@^2.0.0:
   version "2.0.0"
@@ -1575,69 +2240,118 @@ strip-bom@^2.0.0:
   dependencies:
     is-utf8 "^0.2.0"
 
-strip-json-comments@1.0.x, strip-json-comments@~1.0.2:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-1.0.4.tgz#1e15fbcac97d3ee99bf2d73b4c656b082bbafb91"
+strip-bom@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
 
-strip-json-comments@~2.0.1:
+strip-eof@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
+
+strip-json-comments@^2.0.1, strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
-supports-color@3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.1.2.tgz#72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"
+supports-color@5.4.0, supports-color@^5.3.0, supports-color@^5.4.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.4.0.tgz#1c6b337402c2137605efe19f10fec390f6faab54"
   dependencies:
-    has-flag "^1.0.0"
+    has-flag "^3.0.0"
 
 supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
-supports-color@^3.1.0:
+supports-color@^3.1.2:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
   dependencies:
     has-flag "^1.0.0"
 
+symbol-observable@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.1.tgz#8340fc4702c3122df5d22288f88283f513d3fdd4"
+
+table@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/table/-/table-4.0.3.tgz#00b5e2b602f1794b9acaf9ca908a76386a7813bc"
+  dependencies:
+    ajv "^6.0.1"
+    ajv-keywords "^3.0.0"
+    chalk "^2.1.0"
+    lodash "^4.17.4"
+    slice-ansi "1.0.0"
+    string-width "^2.1.1"
+
 taffydb@2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/taffydb/-/taffydb-2.6.2.tgz#7cbcb64b5a141b6a2efc2c5d2c67b4e150b2a268"
 
-through@~2.3.8:
+test-exclude@^4.2.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-4.2.1.tgz#dfa222f03480bca69207ca728b37d74b45f724fa"
+  dependencies:
+    arrify "^1.0.1"
+    micromatch "^3.1.8"
+    object-assign "^4.1.0"
+    read-pkg-up "^1.0.1"
+    require-main-filename "^1.0.1"
+
+text-encoding@^0.6.4:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.6.4.tgz#e399a982257a276dae428bb92845cb71bdc26d19"
+
+text-table@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
+
+through@^2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
-to-double-quotes@^2.0.0:
+tmp@^0.0.33:
+  version "0.0.33"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
+  dependencies:
+    os-tmpdir "~1.0.2"
+
+to-fast-properties@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/to-double-quotes/-/to-double-quotes-2.0.0.tgz#aaf231d6fa948949f819301bbab4484d8588e4a7"
+  resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
 
-to-fast-properties@^1.0.0:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
+to-object-path@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/to-object-path/-/to-object-path-0.3.0.tgz#297588b7b0e7e0ac08e04e672f85c1f4999e17af"
+  dependencies:
+    kind-of "^3.0.2"
 
-to-single-quotes@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/to-single-quotes/-/to-single-quotes-2.0.1.tgz#7cc29151f0f5f2c41946f119f5932fe554170125"
+to-regex-range@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-2.1.1.tgz#7c80c17b9dfebe599e27367e0d4dd5590141db38"
+  dependencies:
+    is-number "^3.0.0"
+    repeat-string "^1.6.1"
 
-trim-right@^1.0.0:
+to-regex@^3.0.1, to-regex@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/to-regex/-/to-regex-3.0.2.tgz#13cfdd9b336552f30b51f33a8ae1b42a7a7599ce"
+  dependencies:
+    define-property "^2.0.2"
+    extend-shallow "^3.0.2"
+    regex-not "^1.0.2"
+    safe-regex "^1.1.0"
+
+trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
 
-try-resolve@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/try-resolve/-/try-resolve-1.0.1.tgz#cfde6fabd72d63e5797cfaab873abbe8e700e912"
-
-tryor@~0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/tryor/-/tryor-0.1.2.tgz#8145e4ca7caff40acde3ccf946e8b8bb75b4172b"
-
-type-check@~0.3.1:
+type-check@~0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
   dependencies:
     prelude-ls "~1.1.2"
 
-type-detect@^4.0.0:
+type-detect@^4.0.0, type-detect@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
 
@@ -1668,55 +2382,48 @@ underscore@~1.8.3:
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
 
-user-home@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/user-home/-/user-home-1.1.1.tgz#2b5be23a32b63a7c9deb8d0f28d485724a3df190"
-
-util-deprecate@~1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
-
-"util@>=0.10.3 <1":
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/util/-/util-0.11.0.tgz#c5f391beb244103d799b21077a926fef8769e1fb"
+union-value@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/union-value/-/union-value-1.0.0.tgz#5c71c34cb5bad5dcebe3ea0cd08207ba5aa1aea4"
   dependencies:
-    inherits "2.0.3"
+    arr-union "^3.1.0"
+    get-value "^2.0.6"
+    is-extendable "^0.1.1"
+    set-value "^0.4.3"
 
-utile@0.2.x:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/utile/-/utile-0.2.1.tgz#930c88e99098d6220834c356cbd9a770522d90d7"
+unset-value@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/unset-value/-/unset-value-1.0.0.tgz#8376873f7d2335179ffb1e6fc3a8ed0dfc8ab559"
   dependencies:
-    async "~0.2.9"
-    deep-equal "*"
-    i "0.3.x"
-    mkdirp "0.x.x"
-    ncp "0.4.x"
-    rimraf "2.x.x"
+    has-value "^0.3.1"
+    isobject "^3.0.0"
 
-uuid@^2.0.2:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
-
-vow-fs@~0.3.4:
-  version "0.3.6"
-  resolved "https://registry.yarnpkg.com/vow-fs/-/vow-fs-0.3.6.tgz#2d4c59be22e2bf2618ddf597ab4baa923be7200d"
+uri-js@^4.2.1:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.2.2.tgz#94c540e1ff772956e2299507c010aea6c8838eb0"
   dependencies:
-    glob "^7.0.5"
-    uuid "^2.0.2"
-    vow "^0.4.7"
-    vow-queue "^0.4.1"
+    punycode "^2.1.0"
 
-vow-queue@^0.4.1:
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/vow-queue/-/vow-queue-0.4.3.tgz#4ba8f64b56e9212c0dbe57f1405aeebd54cce78d"
+urix@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
+
+use@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
+
+validate-npm-package-license@^3.0.1:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz#81643bcbef1bdfecd4623793dc4648948ba98338"
   dependencies:
-    vow "^0.4.17"
+    spdx-correct "^3.0.0"
+    spdx-expression-parse "^3.0.0"
 
-vow@^0.4.17, vow@^0.4.7, vow@~0.4.8:
-  version "0.4.17"
-  resolved "https://registry.yarnpkg.com/vow/-/vow-0.4.17.tgz#b16e08fae58c52f3ebc6875f2441b26a92682904"
+which-module@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
 
-which@^1.1.1:
+which@^1.2.9, which@^1.3.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   dependencies:
@@ -1726,51 +2433,83 @@ window-size@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.0.tgz#5438cd2ea93b202efa3a19fe8887aee7c94f9c9d"
 
-window-size@^0.1.2:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.4.tgz#f8e1aa1ee5a53ec5bf151ffa09742a6ad7697876"
-
-winston@0.8.x:
-  version "0.8.3"
-  resolved "https://registry.yarnpkg.com/winston/-/winston-0.8.3.tgz#64b6abf4cd01adcaefd5009393b1d8e8bec19db0"
-  dependencies:
-    async "0.2.x"
-    colors "0.6.x"
-    cycle "1.0.x"
-    eyes "0.1.x"
-    isstream "0.1.x"
-    pkginfo "0.3.x"
-    stack-trace "0.0.x"
-
 wordwrap@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.2.tgz#b79669bb42ecb409f83d583cad52ca17eaa1643f"
-
-wordwrap@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
 
 wordwrap@~0.0.2:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.3.tgz#a3d5da6cd5c0bc0008d37234bbaf1bed63059107"
 
+wordwrap@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
+
+wrap-ansi@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-2.1.0.tgz#d8fc3d284dd05794fe84973caecdd1cf824fdd85"
+  dependencies:
+    string-width "^1.0.1"
+    strip-ansi "^3.0.1"
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
 
-xmlbuilder@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-3.1.0.tgz#2c86888f2d4eade850fa38ca7f7223f7209516e1"
+write-file-atomic@^1.1.4:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-1.3.4.tgz#f807a4f0b1d9e913ae7a48112e6cc3af1991b45f"
   dependencies:
-    lodash "^3.5.0"
+    graceful-fs "^4.1.11"
+    imurmurhash "^0.1.4"
+    slide "^1.1.5"
+
+write@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/write/-/write-0.2.1.tgz#5fc03828e264cea3fe91455476f7a3c566cb0757"
+  dependencies:
+    mkdirp "^0.5.1"
 
 xmlcreate@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/xmlcreate/-/xmlcreate-1.0.2.tgz#fa6bf762a60a413fb3dd8f4b03c5b269238d308f"
 
-y18n@^3.2.0:
+y18n@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
+
+yallist@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
+
+yargs-parser@^8.0.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-8.1.0.tgz#f1376a33b6629a5d063782944da732631e966950"
+  dependencies:
+    camelcase "^4.1.0"
+
+yargs-parser@^9.0.2:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-9.0.2.tgz#9ccf6a43460fe4ed40a9bb68f48d43b8a68cc077"
+  dependencies:
+    camelcase "^4.1.0"
+
+yargs@11.1.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-11.1.0.tgz#90b869934ed6e871115ea2ff58b03f4724ed2d77"
+  dependencies:
+    cliui "^4.0.0"
+    decamelize "^1.1.1"
+    find-up "^2.1.0"
+    get-caller-file "^1.0.1"
+    os-locale "^2.0.0"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^2.0.0"
+    which-module "^2.0.0"
+    y18n "^3.2.1"
+    yargs-parser "^9.0.2"
 
 yargs@~3.10.0:
   version "3.10.0"
@@ -1780,14 +2519,3 @@ yargs@~3.10.0:
     cliui "^2.1.0"
     decamelize "^1.0.0"
     window-size "0.1.0"
-
-yargs@~3.27.0:
-  version "3.27.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-3.27.0.tgz#21205469316e939131d59f2da0c6d7f98221ea40"
-  dependencies:
-    camelcase "^1.2.1"
-    cliui "^2.1.0"
-    decamelize "^1.0.0"
-    os-locale "^1.4.0"
-    window-size "^0.1.2"
-    y18n "^3.2.0"


### PR DESCRIPTION
Major update with a few breaking changes. Updates packages, linter, drops node 4, drops callbacks.

* Use eslint with conversio config instead of jscs and jshint
* **BREAKING** Drop support for node 4, add CI for node 10 (closes #22)
* **BREAKING** Remove callback interface (closes #23)
* **BREAKING** Use named arguments instead of optional arguments
* Added docs for `top` and `topRange` (closes #20)